### PR TITLE
ci: give apiCheck its own named PR leg

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,13 +54,17 @@ jobs:
             tasks: testAndroidHostTest
           # golden-parity: the SKEEP-003 packed-encoding gate (#1005). Bit-identical decode /
           # scalar-kernel / TurboQuant digests on JVM and Kotlin/Native plus the dispatch parity
-          # tests, and the binary-compatibility check (apiCheck) that the contributing docs require
-          # but the per-target test legs do not run. Fast (a few minutes) so it fails early.
+          # tests. Fast (a few minutes) so it fails early.
           - name: golden-parity
             tasks: >-
-              apiCheck
               :skainet-backends:skainet-backend-cpu:jvmTest --tests sk.ainet.exec.golden.*
               :skainet-backends:skainet-backend-cpu:linuxX64Test --tests sk.ainet.exec.golden.*
+          # api-compatibility: the binary-compatibility check the contributing docs require but the
+          # per-target test legs do not run. Its own leg — not folded into golden-parity — so a
+          # stale api dump reads as "api-compatibility ✘" instead of a red parity leg nobody
+          # associates with dumps (#1171 merged a stale dump exactly that way; #1174 repaired it).
+          - name: api-compatibility
+            tasks: apiCheck
 
     permissions:
       contents: read


### PR DESCRIPTION
apiCheck was already in PR CI — buried inside the `golden-parity` matrix leg (#1005), which is why a stale API dump showed up as a red parity leg nobody associates with binary compatibility, and #1171 merged straight through it (repaired by #1174).

This splits it into its own matrix entry, so a stale dump reads as **`test (api-compatibility)` ✘** with the fix one association away, and `golden-parity` goes back to being purely the packed-encoding gate. The `build-job` aggregator depends on the whole matrix, so no other wiring changes.

**The remaining hole is enforcement, and it is a settings decision, not a workflow one:** nothing blocks merging while checks are red. If you want that closed, branch protection on `develop` requiring `build-job` (the aggregator) does it — one admin toggle; happy to apply it on your word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)