### PR TITLE
chore(compliance): artifact-level third-party notices + BitNet.cpp interpretation credits (#1166)

### DIFF
--- a/skainet-backends/skainet-backend-jni-cpu/src/main/resources/META-INF/THIRD-PARTY-NOTICES.md
+++ b/skainet-backends/skainet-backend-jni-cpu/src/main/resources/META-INF/THIRD-PARTY-NOTICES.md
@@ -1,8 +1,15 @@
+<!--
+SPDX-FileCopyrightText: 2023-2025 Michal Harakal and SKaiNET-developers contributors
+SPDX-License-Identifier: MIT
+-->
+
 # Third-party notices — skainet-backend-jni-cpu
 
-This AAR bundles compiled native libraries (`libskainet_jni.so` /
-`libskainet_jni_v82.so`) that contain code from the following third-party
-project. The MIT license requires this notice to
+This notice travels inside the published `skainet-backend-jni-cpu` AAR on
+Maven Central. That AAR bundles native libraries (`libskainet_jni.so` /
+`libskainet_jni_v82.so`) compiled at release time from source — the source
+repository contains no binaries. The compiled libraries contain code from the
+following third-party project, and the MIT license requires this notice to
 accompany copies and substantial portions of the software — compiled copies
 included.
 

--- a/skainet-backends/skainet-backend-jni-cpu/src/main/resources/META-INF/THIRD-PARTY-NOTICES.md
+++ b/skainet-backends/skainet-backend-jni-cpu/src/main/resources/META-INF/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,46 @@
+# Third-party notices — skainet-backend-jni-cpu
+
+This AAR bundles compiled native libraries (`libskainet_jni.so` /
+`libskainet_jni_v82.so`) that contain code from the following third-party
+project. The MIT license requires this notice to
+accompany copies and substantial portions of the software — compiled copies
+included.
+
+## NeoGPU — ternary LUT NEON kernel
+
+- Upstream: <https://github.com/anjaustin/neogpu>
+- File: `src/hs_ml_ternary_neon.c`, vendored byte-identical at commit `0846b24`
+  (see `native/src/vendor/neogpu/README.md` in the source tree)
+- Vendoring agreed with upstream in
+  [anjaustin/neogpu#1](https://github.com/anjaustin/neogpu/issues/1)
+
+```
+MIT License
+
+Copyright (c) 2024 NeoGPU Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## Format-knowledge attribution (no code shipped)
+
+The I2_S GGUF wire-format handling in `skainet-io-gguf` was written against the
+sources of [BitNet.cpp](https://github.com/microsoft/BitNet) (MIT, © Microsoft
+Corporation) — a reimplementation of the layout rules, not copied code. See the
+interpretation notes in `sk.ainet.io.gguf.I2sRepack`.

--- a/skainet-backends/skainet-backend-jni-cpu/src/main/resources/META-INF/THIRD-PARTY-NOTICES.md
+++ b/skainet-backends/skainet-backend-jni-cpu/src/main/resources/META-INF/THIRD-PARTY-NOTICES.md
@@ -1,6 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2023-2025 Michal Harakal and SKaiNET-developers contributors
-SPDX-License-Identifier: MIT
+SPDX-License-Identifier: CC0-1.0
 -->
 
 # Third-party notices — skainet-backend-jni-cpu

--- a/skainet-backends/skainet-backend-native-cpu/native/src/vendor/neogpu/README.md
+++ b/skainet-backends/skainet-backend-native-cpu/native/src/vendor/neogpu/README.md
@@ -1,8 +1,15 @@
+<!--
+SPDX-FileCopyrightText: 2023-2025 Michal Harakal and SKaiNET-developers contributors
+SPDX-License-Identifier: MIT
+-->
+
 # Vendored: NeoGPU ternary LUT kernel
 
 Byte-identical copy of one file from the NeoGPU project, vendored under its
-MIT license (see the REUSE `.license` sidecar; `LICENSES/MIT.txt` at the repo
-root carries the license text). Agreed with upstream in
+MIT license. Because the file must stay byte-identical to upstream, its SPDX
+copyright and license header lives in the REUSE `.license` sidecar
+(`hs_ml_ternary_neon.c.license`) instead of the file itself; `LICENSES/MIT.txt`
+at the repo root carries the license text. Agreed with upstream in
 [anjaustin/neogpu#1](https://github.com/anjaustin/neogpu/issues/1); SKaiNET
 tracking issue: [#1136](https://github.com/SKaiNET-developers/SKaiNET/issues/1136).
 
@@ -47,7 +54,9 @@ Exports three symbols; SKaiNET wraps the first two via
 
 ## Shipped-artifact notices
 
-Compiled copies of this file travel inside published artifacts (the
+Only this C source file is checked into the repository — no compiled binaries
+live in the tree. Compilation happens at build/release time, and the compiled
+copies exist only inside the artifacts published to Maven Central (the
 `skainet-backend-native-cpu` jar/klibs and the `skainet-backend-jni-cpu` AAR).
 MIT's notice obligation follows them: each of those artifacts carries
 `META-INF/THIRD-PARTY-NOTICES.md` with the NeoGPU copyright and license text.

--- a/skainet-backends/skainet-backend-native-cpu/native/src/vendor/neogpu/README.md
+++ b/skainet-backends/skainet-backend-native-cpu/native/src/vendor/neogpu/README.md
@@ -45,6 +45,14 @@ Exports three symbols; SKaiNET wraps the first two via
   default `-march=armv8.2-a+fp16+dotprod` would defeat its purpose
   (dotprod-less targets).
 
+## Shipped-artifact notices
+
+Compiled copies of this file travel inside published artifacts (the
+`skainet-backend-native-cpu` jar/klibs and the `skainet-backend-jni-cpu` AAR).
+MIT's notice obligation follows them: each of those artifacts carries
+`META-INF/THIRD-PARTY-NOTICES.md` with the NeoGPU copyright and license text.
+Keep those notices in sync with this README when re-vendoring.
+
 ## Re-vendoring
 
 Copy the file byte-identical from upstream, update the commit + SHA-256 here,

--- a/skainet-backends/skainet-backend-native-cpu/native/src/vendor/neogpu/README.md
+++ b/skainet-backends/skainet-backend-native-cpu/native/src/vendor/neogpu/README.md
@@ -1,15 +1,18 @@
 <!--
 SPDX-FileCopyrightText: 2023-2025 Michal Harakal and SKaiNET-developers contributors
-SPDX-License-Identifier: MIT
+SPDX-License-Identifier: CC0-1.0
 -->
 
 # Vendored: NeoGPU ternary LUT kernel
 
 Byte-identical copy of one file from the NeoGPU project, vendored under its
-MIT license. Because the file must stay byte-identical to upstream, its SPDX
-copyright and license header lives in the REUSE `.license` sidecar
-(`hs_ml_ternary_neon.c.license`) instead of the file itself; `LICENSES/MIT.txt`
-at the repo root carries the license text. Agreed with upstream in
+MIT license. The file is kept byte-identical so its provenance is verifiable:
+the SHA-256 in the table below can be checked directly against the file at the
+upstream commit. Any in-file edit — including adding an SPDX comment header —
+would change that hash, so the SPDX copyright and license info lives in the
+REUSE `.license` sidecar (`hs_ml_ternary_neon.c.license`) instead;
+`LICENSES/MIT.txt` at the repo root carries the license text. Agreed with
+upstream in
 [anjaustin/neogpu#1](https://github.com/anjaustin/neogpu/issues/1); SKaiNET
 tracking issue: [#1136](https://github.com/SKaiNET-developers/SKaiNET/issues/1136).
 

--- a/skainet-backends/skainet-backend-native-cpu/src/jvmMain/resources/META-INF/THIRD-PARTY-NOTICES.md
+++ b/skainet-backends/skainet-backend-native-cpu/src/jvmMain/resources/META-INF/THIRD-PARTY-NOTICES.md
@@ -1,6 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2023-2025 Michal Harakal and SKaiNET-developers contributors
-SPDX-License-Identifier: MIT
+SPDX-License-Identifier: CC0-1.0
 -->
 
 # Third-party notices — skainet-backend-native-cpu

--- a/skainet-backends/skainet-backend-native-cpu/src/jvmMain/resources/META-INF/THIRD-PARTY-NOTICES.md
+++ b/skainet-backends/skainet-backend-native-cpu/src/jvmMain/resources/META-INF/THIRD-PARTY-NOTICES.md
@@ -1,8 +1,16 @@
+<!--
+SPDX-FileCopyrightText: 2023-2025 Michal Harakal and SKaiNET-developers contributors
+SPDX-License-Identifier: MIT
+-->
+
 # Third-party notices — skainet-backend-native-cpu
 
-This artifact bundles a compiled native library (`libskainet_kernels.{so,dylib,dll}`,
-and the static archive embedded in the Kotlin/Native klibs) that contains code
-from the following third-party project. The MIT license requires this notice to
+This notice travels inside the published `skainet-backend-native-cpu`
+artifacts on Maven Central. Those artifacts bundle a native library
+(`libskainet_kernels.{so,dylib,dll}`, and the static archive embedded in the
+Kotlin/Native klibs) compiled at release time from source — the source
+repository contains no binaries. The compiled library contains code from the
+following third-party project, and the MIT license requires this notice to
 accompany copies and substantial portions of the software — compiled copies
 included.
 

--- a/skainet-backends/skainet-backend-native-cpu/src/jvmMain/resources/META-INF/THIRD-PARTY-NOTICES.md
+++ b/skainet-backends/skainet-backend-native-cpu/src/jvmMain/resources/META-INF/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,46 @@
+# Third-party notices — skainet-backend-native-cpu
+
+This artifact bundles a compiled native library (`libskainet_kernels.{so,dylib,dll}`,
+and the static archive embedded in the Kotlin/Native klibs) that contains code
+from the following third-party project. The MIT license requires this notice to
+accompany copies and substantial portions of the software — compiled copies
+included.
+
+## NeoGPU — ternary LUT NEON kernel
+
+- Upstream: <https://github.com/anjaustin/neogpu>
+- File: `src/hs_ml_ternary_neon.c`, vendored byte-identical at commit `0846b24`
+  (see `native/src/vendor/neogpu/README.md` in the source tree)
+- Vendoring agreed with upstream in
+  [anjaustin/neogpu#1](https://github.com/anjaustin/neogpu/issues/1)
+
+```
+MIT License
+
+Copyright (c) 2024 NeoGPU Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## Format-knowledge attribution (no code shipped)
+
+The I2_S GGUF wire-format handling in `skainet-io-gguf` was written against the
+sources of [BitNet.cpp](https://github.com/microsoft/BitNet) (MIT, © Microsoft
+Corporation) — a reimplementation of the layout rules, not copied code. See the
+interpretation notes in `sk.ainet.io.gguf.I2sRepack`.

--- a/skainet-io/skainet-io-gguf/src/commonMain/kotlin/sk/ainet/io/gguf/Constants.kt
+++ b/skainet-io/skainet-io-gguf/src/commonMain/kotlin/sk/ainet/io/gguf/Constants.kt
@@ -3,6 +3,9 @@ package sk.ainet.io.gguf
 /**
  * This is a kotlin gguf reader related logic interpreted from python code "gguf-py/gguf/constants.py"
  * of github repo "https://github.com/ggerganov/llama.cpp"
+ *
+ * The I2_S entry (type 36) is interpreted from the sources of
+ * "https://github.com/microsoft/BitNet" (BitNet.cpp, MIT) — see the layout notes in I2sRepack.kt.
  */
 
 const val GGUF_MAGIC = 0x46554747u

--- a/skainet-io/skainet-io-gguf/src/commonMain/kotlin/sk/ainet/io/gguf/Constants.kt
+++ b/skainet-io/skainet-io-gguf/src/commonMain/kotlin/sk/ainet/io/gguf/Constants.kt
@@ -6,6 +6,9 @@ package sk.ainet.io.gguf
  *
  * The I2_S entry (type 36) is interpreted from the sources of
  * "https://github.com/microsoft/BitNet" (BitNet.cpp, MIT) — see the layout notes in I2sRepack.kt.
+ * 
+ * SPDX-FileCopyrightText:  Copyright (c) Microsoft Corporation
+ * SPDX-License-Identifier: MIT
  */
 
 const val GGUF_MAGIC = 0x46554747u

--- a/skainet-io/skainet-io-gguf/src/commonMain/kotlin/sk/ainet/io/gguf/I2sRepack.kt
+++ b/skainet-io/skainet-io-gguf/src/commonMain/kotlin/sk/ainet/io/gguf/I2sRepack.kt
@@ -1,13 +1,16 @@
 package sk.ainet.io.gguf
 
-// The I2_S layout rules in this file are interpreted from the sources of
-// https://github.com/microsoft/BitNet (BitNet.cpp, MIT, © Microsoft Corporation) —
-// `quantize_i2_s` in src/ggml-bitnet-mad.cpp — and from NeoGPU's
-// tools/convert_bitnet_to_gguf.py (https://github.com/anjaustin/neogpu, MIT).
-// A clean-room reimplementation of the format, not copied code — the same
-// convention as the llama.cpp note in Constants.kt.
-// SPDX-FileCopyrightText: Copyright (c) Microsoft Corporation
-// SPDX-License-Identifier: MIT
+/*
+ * The I2_S layout rules in this file are interpreted from the sources of
+ * "https://github.com/microsoft/BitNet" (BitNet.cpp, MIT, © Microsoft Corporation) —
+ * `quantize_i2_s` in src/ggml-bitnet-mad.cpp — and from NeoGPU's
+ * tools/convert_bitnet_to_gguf.py ("https://github.com/anjaustin/neogpu", MIT).
+ * A clean-room reimplementation of the format, not copied code — the same
+ * convention as the llama.cpp note in Constants.kt.
+ *
+ * SPDX-FileCopyrightText:  Copyright (c) Microsoft Corporation
+ * SPDX-License-Identifier: MIT
+ */
 /**
  * Which bit order an I2_S GGUF's payload is in — a property of the *converter that wrote the
  * file*, not recoverable from the bytes, so the caller has to say (#1140).

--- a/skainet-io/skainet-io-gguf/src/commonMain/kotlin/sk/ainet/io/gguf/I2sRepack.kt
+++ b/skainet-io/skainet-io-gguf/src/commonMain/kotlin/sk/ainet/io/gguf/I2sRepack.kt
@@ -1,5 +1,12 @@
 package sk.ainet.io.gguf
 
+// The I2_S layout rules in this file are interpreted from the sources of
+// https://github.com/microsoft/BitNet (BitNet.cpp, MIT, © Microsoft Corporation) —
+// `quantize_i2_s` in src/ggml-bitnet-mad.cpp — and from NeoGPU's
+// tools/convert_bitnet_to_gguf.py (https://github.com/anjaustin/neogpu, MIT).
+// A clean-room reimplementation of the format, not copied code — the same
+// convention as the llama.cpp note in Constants.kt.
+
 /**
  * Which bit order an I2_S GGUF's payload is in — a property of the *converter that wrote the
  * file*, not recoverable from the bytes, so the caller has to say (#1140).

--- a/skainet-io/skainet-io-gguf/src/commonMain/kotlin/sk/ainet/io/gguf/I2sRepack.kt
+++ b/skainet-io/skainet-io-gguf/src/commonMain/kotlin/sk/ainet/io/gguf/I2sRepack.kt
@@ -6,7 +6,8 @@ package sk.ainet.io.gguf
 // tools/convert_bitnet_to_gguf.py (https://github.com/anjaustin/neogpu, MIT).
 // A clean-room reimplementation of the format, not copied code — the same
 // convention as the llama.cpp note in Constants.kt.
-
+// SPDX-FileCopyrightText: Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
 /**
  * Which bit order an I2_S GGUF's payload is in — a property of the *converter that wrote the
  * file*, not recoverable from the bytes, so the caller has to say (#1140).


### PR DESCRIPTION
Part of #1166 (the final gate of #1136) — the items that don't need a release or a model file.

## What

- **`META-INF/THIRD-PARTY-NOTICES.md`** in `skainet-backend-native-cpu` (verified: lands in the jvm jar next to the bundled `libskainet_kernels`) and `skainet-backend-jni-cpu` (AAR) — NeoGPU copyright + full MIT text + the BitNet.cpp format-knowledge note. This is the artifact-level obligation `reuse lint` can't see: compiled copies of the vendored kernel travel in published artifacts.
- **Interpretation credits** for the I2_S wire format: BitNet.cpp (MIT, © Microsoft) named in `I2sRepack.kt` and the `Constants.kt` header, following the existing llama.cpp precedent.
- Vendor README cross-references the notices for re-vendoring hygiene.

## #1166 checklist status after this PR

- ✅ `reuse lint` in CI — already existed (`reuse-compliance.yml`), green on every ternary PR
- ✅ Vendored file byte-identical — re-verified now: `a560ffcf…` matches the recorded `anjaustin/neogpu@0846b24`
- ✅ `LICENSES/` audit — Apache-2.0 and CC0-1.0 are *referenced* (gradle wrapper, `onnx-ml.proto3`; FSFE/Scorecard workflows): justified, kept
- ✅ BitNet.cpp interpretation note (this PR)
- ✅ Artifact-level notices (this PR)
- ⬜ POM/release-notes mention + BOM — at release cut
- ⬜ Upstream courtesies (comment on anjaustin/neogpu#1, "used by" PR) — proposed text in the tracking issue, needs the maintainer's go
- ⬜ Real `microsoft/bitnet-b1.58-2B-4T` GGUF verification — needs the model file
- ⬜ Close-out summary + CHANGELOG — at release cut

🤖 Generated with [Claude Code](https://claude.com/claude-code)