### PR TITLE
fix(cpu): off-heap activations reach the ternary dispatch path (#1136)

### DIFF
--- a/skainet-backends/skainet-backend-cpu/src/jvmMain/kotlin/sk/ainet/exec/tensor/ops/DefaultCpuOpsJvm.kt
+++ b/skainet-backends/skainet-backend-cpu/src/jvmMain/kotlin/sk/ainet/exec/tensor/ops/DefaultCpuOpsJvm.kt
@@ -191,7 +191,18 @@ internal class DefaultCpuOpsJvm(
      */
     @Suppress("UNCHECKED_CAST")
     override fun <T : DType, V> matmulWeightTransposed(x: Tensor<T, V>, weight: Tensor<T, V>): Tensor<T, V> {
-        if (weight.shape.rank != 2 || !isHeapPackedWeightForJvm(weight.data)) return super.matmulWeightTransposed(x, weight)
+        if (weight.shape.rank != 2 || !isHeapPackedWeightForJvm(weight.data)) {
+            // Packed weights OUTSIDE the JVM relayout list (the ternary formats, #1136) go to the
+            // common views→KernelDispatch path — whose kernels and reference are commonMain and
+            // cannot read a MemorySegment-backed activation (SKEEP-004 forbids element access over
+            // SegmentStorage by design). On this tier the bridge is trivial: bulk-copy the
+            // activation to the heap once per call — decode-step activations are k floats, not
+            // weights — and hand the common path heap views.
+            if (weight.data is sk.ainet.lang.tensor.storage.PackedBlockStorage) {
+                segmentActivationToHeap(x)?.let { return super.matmulWeightTransposed(it, weight) }
+            }
+            return super.matmulWeightTransposed(x, weight)
+        }
         // Already in feed order — the loader produced it that way (#1120). Nothing to permute and
         // nothing to cache: the kernels want the other shape label over the same bytes, which costs
         // an object rather than a copy of the weight.
@@ -204,6 +215,39 @@ internal class DefaultCpuOpsJvm(
             prepackedWeightsJvm.add(Pair(source, relayouted as Tensor<*, *>))
         }
         return matmul(x, kernelOrder as Tensor<T, V>)
+    }
+
+    /**
+     * A heap FP32 copy of an activation whose bytes live off-heap, or null when [x] is not that
+     * shape. Two producers exist on this tier: TensorData that is itself segment-backed
+     * ([MemorySegmentBackedData]), and TensorData whose VIEW presents a
+     * [sk.ainet.lang.memory.SegmentStorage] (SKEEP-004 off-heap scope allocations).
+     */
+    @OptIn(sk.ainet.lang.memory.ExperimentalMemoryApi::class)
+    private fun <T : DType, V> segmentActivationToHeap(x: Tensor<T, V>): Tensor<T, V>? {
+        if (x.dtype != FP32::class) return null
+        val count = x.shape.volume
+        val arr = FloatArray(count)
+        val src = x.data as? MemorySegmentBackedData
+        if (src != null) {
+            java.lang.foreign.MemorySegment.copy(
+                src.segment, java.lang.foreign.ValueLayout.JAVA_FLOAT, src.segmentByteOffset, arr, 0, count,
+            )
+        } else {
+            val view = x.data.view ?: return null
+            if (!view.isContiguous) return null
+            val seg = view.storage as? sk.ainet.lang.memory.SegmentStorage ?: return null
+            java.lang.foreign.MemorySegment.copy(
+                seg.segment(), java.lang.foreign.ValueLayout.JAVA_FLOAT,
+                view.layout.offsetElements * java.lang.Float.BYTES.toLong(), arr, 0, count,
+            )
+        }
+        // NOT dataFactory.adoptFloatArray: this JVM factory adopts float arrays back INTO
+        // MemorySegments — the round-trip that defeats the whole copy. The base heap class is
+        // what the common dispatch path can read.
+        @Suppress("UNCHECKED_CAST")
+        val data = sk.ainet.lang.tensor.data.DenseFloatArrayTensorData<T>(x.shape, arr) as sk.ainet.lang.tensor.data.TensorData<T, V>
+        return newTensor(data, x.dtype, x)
     }
 
     /** Relayouted weights keyed by the identity of the bytes they came from (#1096). */


### PR DESCRIPTION
Targeted at `release/0.49.0` — found running the real `microsoft/bitnet-b1.58-2B-4T` I2_S GGUF end-to-end in SKaiNET-transformers on the 0.49 line.

## Root cause

SKEEP-004 puts JVM activations in MemorySegments, and forbids element access over `SegmentStorage` ("use a kernel"). The common views→`KernelDispatch` path that packed **ternary** weights take (unlike the Q-formats, which have their own JVM MemSeg tier) receives the activation view as-is — and both the ternary kernels' array unwrap and the commonMain reference fall over the segment.

## Fix

`DefaultCpuOpsJvm.matmulWeightTransposed`: when the weight is a packed-block weight outside the JVM relayout list, bulk-copy a segment-backed activation to the heap once per call (k floats — noise next to the matmul). Handles both producers: `MemorySegmentBackedData` and view-level `SegmentStorage`. The copy constructs `DenseFloatArrayTensorData` **directly** — this tier's `dataFactory.adoptFloatArray` adopts arrays back *into* segments, which silently round-trips the problem (ask me how I know).

## Verified

- `backend-cpu` jvm suite green.
- **The real 2B4T model generates coherent text** through the packed path + vendored NEON kernels: *"The capital of France is Paris. Paris is known for its beautiful architecture, art, and cuisine…"* — greedy decode, 64 tokens. This also **confirms the `GROUP_128` default** of the I2_S import against the official BitNet.cpp file (#1140's open verification caveat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)