### PR TITLE
Off-heap storage + zero-copy native gemv for ternary weights (#1202)

### DIFF
--- a/skainet-backends/skainet-backend-api/src/commonMain/kotlin/sk/ainet/backend/api/kernel/BitNetGemvKernel.kt
+++ b/skainet-backends/skainet-backend-api/src/commonMain/kotlin/sk/ainet/backend/api/kernel/BitNetGemvKernel.kt
@@ -76,10 +76,12 @@ public class BitNetGemvKernel(override val key: KernelKey) : ViewKernel {
         }
     }
 
-    private fun weightBytes(w: TensorView): ByteArray {
-        val heap = w.storage as? Storage.Heap
-            ?: throw UnsupportedOperationException("bitnet_gemv reads ternary weights from heap storage in this milestone")
-        return heap.bytes ?: throw UnsupportedOperationException("ternary weights need byte storage")
+    private fun weightBytes(w: TensorView): ByteArray = when (val storage = w.storage) {
+        is Storage.Heap -> storage.bytes ?: throw UnsupportedOperationException("ternary weights need byte storage")
+        // Off-heap/mapped weights (#1202): a transient snapshot, not a standing heap copy — this
+        // reference kernel is the slow/fallback path already, so the extra copy here doesn't
+        // regress the fast native path's residency.
+        else -> ByteArray(storage.sizeBytes.toInt()).also { storage.copyInto(it) }
     }
 
     /** Elements per scale: a GGML block, or the whole tensor for the per-tensor BitNet encoding. */

--- a/skainet-backends/skainet-backend-api/src/commonMain/kotlin/sk/ainet/backend/api/kernel/TernaryF32GemvKernel.kt
+++ b/skainet-backends/skainet-backend-api/src/commonMain/kotlin/sk/ainet/backend/api/kernel/TernaryF32GemvKernel.kt
@@ -51,8 +51,7 @@ public class TernaryF32GemvKernel(override val key: KernelKey) : ViewKernel {
         require(out.shape[0] == rows && out.shape[1] == n) { "out must be [$rows, $n], was ${out.shape}" }
         if (rows == 0 || n == 0) return
 
-        val bytes = weightBytes(w)
-        val byteOffset = (w.storage as Storage.Heap).arrayOffset
+        val (bytes, byteOffset) = weightBytes(w)
         // Codes are hoisted out of the row loop, and the per-tensor scale out of everything.
         val codes = TernaryCodec.codes(TensorEncoding.BITNET_B1_58, bytes, n * k, byteOffset)
         val scale = TernaryCodec.bitNetScale(bytes, n * k, byteOffset)
@@ -74,10 +73,14 @@ public class TernaryF32GemvKernel(override val key: KernelKey) : ViewKernel {
         }
     }
 
-    private fun weightBytes(w: TensorView): ByteArray {
-        val heap = w.storage as? Storage.Heap
-            ?: throw UnsupportedOperationException("ternary_f32_gemv reads ternary weights from heap storage in this milestone")
-        return heap.bytes ?: throw UnsupportedOperationException("ternary weights need byte storage")
+    /** The weight's bytes and the byte offset codes/scale should be read from within them. */
+    private fun weightBytes(w: TensorView): Pair<ByteArray, Int> = when (val storage = w.storage) {
+        is Storage.Heap -> (storage.bytes ?: throw UnsupportedOperationException("ternary weights need byte storage")) to storage.arrayOffset
+        // Off-heap/mapped weights (#1202): a transient snapshot, not a standing heap copy — this
+        // reference kernel is the slow/fallback path already, so the extra copy here doesn't
+        // regress the fast native path's residency. The snapshot is tensor-sized, so the codec
+        // reads it from offset 0 regardless of where the storage itself lives.
+        else -> ByteArray(storage.sizeBytes.toInt()).also { storage.copyInto(it) } to 0
     }
 
     public companion object {

--- a/skainet-backends/skainet-backend-api/src/commonMain/kotlin/sk/ainet/backend/api/kernel/TernaryF32KernelPack.kt
+++ b/skainet-backends/skainet-backend-api/src/commonMain/kotlin/sk/ainet/backend/api/kernel/TernaryF32KernelPack.kt
@@ -33,6 +33,32 @@ public interface TernaryF32GemvNative {
         out: FloatArray,
         outOffset: Int,
     )
+
+    /**
+     * The same call, [weight] backed by [Storage.OffHeap]/[Storage.Mapped] instead of a heap
+     * `ByteArray` (#1202). Implementations that can read the storage's native handle directly
+     * (e.g. the JVM FFM face reading a `SegmentStorage`'s `MemorySegment`) should override this to
+     * skip materializing a copy of the weight on every call — the weight is invariant across the
+     * row loop a [ViewKernel] runs, so a per-row snapshot here is the exact cost the sidecar/
+     * off-heap work in #1202 was meant to eliminate, not preserve.
+     *
+     * The default is still correct everywhere: one transient snapshot, then [gemvPacked].
+     */
+    @sk.ainet.lang.memory.ExperimentalMemoryApi
+    public fun gemvPackedStorage(
+        activation: FloatArray,
+        activationOffset: Int,
+        weight: sk.ainet.lang.memory.Storage,
+        weightByteOffset: Int,
+        inputDim: Int,
+        outputDim: Int,
+        out: FloatArray,
+        outOffset: Int,
+    ) {
+        val bytes = ByteArray(weight.sizeBytes.toInt())
+        weight.copyInto(bytes)
+        gemvPacked(activation, activationOffset, bytes, weightByteOffset, inputDim, outputDim, out, outOffset)
+    }
 }
 
 /**
@@ -110,35 +136,68 @@ public class NativeTernaryF32ViewKernel(
         val k = a.shape[1]
         val n = w.shape[0]
         val activationFloats = (a.storage as? Storage.Heap)?.floats
-        val weightBytes = (w.storage as? Storage.Heap)?.bytes
         val outFloats = (out.storage as? Storage.Heap)?.floats
-        if (k % 4 != 0 || activationFloats == null || weightBytes == null || outFloats == null ||
-            !a.isContiguous || !out.isContiguous
-        ) {
+        if (k % 4 != 0 || activationFloats == null || outFloats == null || !a.isContiguous || !out.isContiguous) {
             reference.run(inputs, out)
             return
         }
         if (rows == 0 || n == 0) return
         val aOffset = (a.storage as Storage.Heap).arrayOffset
-        val wOffset = (w.storage as Storage.Heap).arrayOffset
         val outOffset = (out.storage as Storage.Heap).arrayOffset
-        for (r in 0 until rows) {
-            native.gemvPacked(
-                activation = activationFloats,
-                activationOffset = aOffset + r * k,
-                weight = weightBytes,
-                weightByteOffset = wOffset,
-                inputDim = k,
-                outputDim = n,
-                out = outFloats,
-                outOffset = outOffset + r * n,
-            )
-        }
-        // The native kernel computes the unscaled codes-dot; the per-tensor scale lives in the
-        // weight's trailing FP32 and is applied once, here.
-        val scale = TernaryCodec.bitNetScale(weightBytes, n * k, wOffset)
-        if (scale != 1f) {
-            for (i in outOffset until outOffset + rows * n) outFloats[i] *= scale
+
+        when (val weightStorage = w.storage) {
+            is Storage.Heap -> {
+                val weightBytes = weightStorage.bytes
+                if (weightBytes == null) {
+                    reference.run(inputs, out)
+                    return
+                }
+                val wOffset = weightStorage.arrayOffset
+                for (r in 0 until rows) {
+                    native.gemvPacked(
+                        activation = activationFloats,
+                        activationOffset = aOffset + r * k,
+                        weight = weightBytes,
+                        weightByteOffset = wOffset,
+                        inputDim = k,
+                        outputDim = n,
+                        out = outFloats,
+                        outOffset = outOffset + r * n,
+                    )
+                }
+                // The native kernel computes the unscaled codes-dot; the per-tensor scale lives
+                // in the weight's trailing FP32 and is applied once, here.
+                val scale = TernaryCodec.bitNetScale(weightBytes, n * k, wOffset)
+                if (scale != 1f) {
+                    for (i in outOffset until outOffset + rows * n) outFloats[i] *= scale
+                }
+            }
+            is Storage.OffHeap, is Storage.Mapped -> {
+                // #1202: an off-heap/mapped weight never had a standing ByteArray to begin with —
+                // gemvPackedStorage lets the native face read it directly (zero-copy where the
+                // implementation supports it) instead of manufacturing one per row.
+                for (r in 0 until rows) {
+                    native.gemvPackedStorage(
+                        activation = activationFloats,
+                        activationOffset = aOffset + r * k,
+                        weight = weightStorage,
+                        weightByteOffset = 0,
+                        inputDim = k,
+                        outputDim = n,
+                        out = outFloats,
+                        outOffset = outOffset + r * n,
+                    )
+                }
+                // Same trailing-FP32 scale as the heap case, but only the 4 scale bytes are
+                // copied out — not the whole weight — to read it.
+                val scaleBytes = ByteArray(4)
+                weightStorage.copyInto(scaleBytes, offset = weightStorage.sizeBytes - 4, length = 4)
+                val scale = TernaryCodec.bitNetScale(scaleBytes, 0, 0)
+                if (scale != 1f) {
+                    for (i in outOffset until outOffset + rows * n) outFloats[i] *= scale
+                }
+            }
+            else -> reference.run(inputs, out)
         }
     }
 }

--- a/skainet-backends/skainet-backend-api/src/commonTest/kotlin/sk/ainet/backend/api/kernel/TernaryF32KernelPackTest.kt
+++ b/skainet-backends/skainet-backend-api/src/commonTest/kotlin/sk/ainet/backend/api/kernel/TernaryF32KernelPackTest.kt
@@ -1,14 +1,20 @@
 package sk.ainet.backend.api.kernel
 
 import sk.ainet.lang.memory.ExperimentalMemoryApi
+import sk.ainet.lang.memory.Owner
 import sk.ainet.lang.memory.Scope
+import sk.ainet.lang.memory.ScopeKind
 import sk.ainet.lang.memory.Storage
+import sk.ainet.lang.memory.StorageId
 import sk.ainet.lang.memory.TensorView
 import sk.ainet.lang.memory.TernaryBlockDecoder
 import sk.ainet.lang.memory.TernaryCodec
+import sk.ainet.lang.memory.trace.NoopTraceSink
 import sk.ainet.lang.memory.trace.RecordingTraceSink
 import sk.ainet.lang.memory.trace.TraceEvent
+import sk.ainet.lang.memory.trace.TraceSink
 import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.TensorId
 import sk.ainet.lang.tensor.storage.TensorEncoding
 import sk.ainet.lang.types.FP32
 import kotlin.math.abs
@@ -52,6 +58,33 @@ class TernaryF32KernelPackTest {
                 }
                 out[outOffset + o] = acc
             }
+        }
+    }
+
+    /**
+     * A minimal non-Heap [Storage] usable from `commonTest` (no platform off-heap type is
+     * constructible here) — enough to exercise [NativeTernaryF32ViewKernel]'s `is Storage.OffHeap`
+     * branch and its [TernaryF32GemvNative.gemvPackedStorage] dispatch without a real JVM/Native
+     * off-heap allocation. The zero-copy behavior itself (a real `MemorySegment`) is pinned by
+     * `NativeTernaryF32GemvKernelTest` in skainet-backend-native-cpu.
+     */
+    private class FakeOffHeapStorage(private val bytes: ByteArray) : Storage.OffHeap() {
+        override val id: StorageId = StorageId.next()
+        override val sizeBytes: Long get() = bytes.size.toLong()
+        override val owner: Owner = Owner.Owned(ScopeKind.AMBIENT)
+        override val debugOrigin: TensorId? = null
+        override val sink: TraceSink = NoopTraceSink
+        override val isMutable: Boolean get() = true
+
+        override fun slice(offsetBytes: Long, lengthBytes: Long): Storage =
+            FakeOffHeapStorage(bytes.copyOfRange(offsetBytes.toInt(), (offsetBytes + lengthBytes).toInt()))
+
+        override fun copyInto(dest: ByteArray, destOffset: Int, offset: Long, length: Int) {
+            bytes.copyInto(dest, destOffset, offset.toInt(), offset.toInt() + length)
+        }
+
+        override fun copyFrom(src: ByteArray, srcOffset: Int, offset: Long, length: Int) {
+            src.copyInto(bytes, offset.toInt(), srcOffset, srcOffset + length)
         }
     }
 
@@ -138,6 +171,44 @@ class TernaryF32KernelPackTest {
 
         val fromReference = TensorView.dense(Storage.Heap.floats(rows * n), Shape(rows, n), FP32)
         TernaryF32GemvKernel(TernaryF32GemvKernel.keyFor()).run(listOf(a, w), fromReference)
+        for (r in 0 until rows) for (o in 0 until n) {
+            val got = out.get(r, o)
+            val want = fromReference.get(r, o)
+            assertTrue(abs(got - want) <= 1e-5f * maxOf(1f, abs(want)), "[$r,$o]: $got vs $want")
+        }
+    }
+
+    @Test
+    fun offHeapWeightStorageStillTakesTheNativePathNotTheReferenceFallback() {
+        // #1202: shipping off-heap ternary storage must not silently regress the native path to
+        // the slow reference kernel — this is the direct regression test for that risk.
+        val native = FakeNative()
+        TernaryF32KernelPack.install(native)
+        val rows = 2
+        val a = activation(rows)
+
+        var seed = 5
+        val values = FloatArray(n * k) {
+            seed = seed * 1103515245 + 12345
+            ((seed ushr 16) % 3 - 1) * 0.5f
+        }
+        val bytes = TernaryCodec.encodeBitNet(values)
+        val offHeapStorage = FakeOffHeapStorage(bytes)
+        val w = TensorView.packed(
+            offHeapStorage, Shape(n, k), TensorEncoding.BITNET_B1_58,
+            TernaryBlockDecoder(TensorEncoding.BITNET_B1_58, n * k),
+        )
+
+        val out = TensorView.dense(Storage.Heap.floats(rows * n), Shape(rows, n), FP32)
+        NativeTernaryF32ViewKernel(native, TernaryF32GemvKernel.keyFor()).run(listOf(a, w), out)
+        assertEquals(rows, native.calls, "off-heap weight must still dispatch to the native kernel, once per row")
+
+        val fromReference = TensorView.dense(Storage.Heap.floats(rows * n), Shape(rows, n), FP32)
+        val heapWeight = TensorView.packed(
+            Storage.Heap.wrap(bytes), Shape(n, k), TensorEncoding.BITNET_B1_58,
+            TernaryBlockDecoder(TensorEncoding.BITNET_B1_58, n * k),
+        )
+        TernaryF32GemvKernel(TernaryF32GemvKernel.keyFor()).run(listOf(a, heapWeight), fromReference)
         for (r in 0 until rows) for (o in 0 until n) {
             val got = out.get(r, o)
             val want = fromReference.get(r, o)

--- a/skainet-backends/skainet-backend-native-cpu/src/jvmMain/kotlin/sk/ainet/exec/kernel/NativeTernaryF32GemvKernel.kt
+++ b/skainet-backends/skainet-backend-native-cpu/src/jvmMain/kotlin/sk/ainet/exec/kernel/NativeTernaryF32GemvKernel.kt
@@ -9,6 +9,8 @@ import java.lang.invoke.MethodHandle
 import sk.ainet.backend.api.kernel.TernaryF32GemvNative
 import sk.ainet.backend.api.kernel.TernaryF32KernelPack
 import sk.ainet.lang.memory.ExperimentalMemoryApi
+import sk.ainet.lang.memory.SegmentStorage
+import sk.ainet.lang.memory.Storage
 
 /**
  * Native (FFM) downcall to the vendored NeoGPU ternary LUT kernel.
@@ -101,6 +103,65 @@ public object NativeTernaryF32GemvKernel : TernaryF32GemvNative {
 
             mh.invoke(
                 inputSeg, inputOffset,
+                weightSeg, weightByteOffset,
+                inputDim, outputDim,
+                outputSeg, outputOffset,
+            )
+
+            MemorySegment.copy(outputSeg, ValueLayout.JAVA_FLOAT, 0L, output, 0, outputReachFloats)
+        }
+    }
+
+    /**
+     * The zero-copy face of [gemvPacked] (#1202): when [weight] is a [SegmentStorage] its
+     * `MemorySegment` is handed to the native call directly — the weight is never copied, not even
+     * once, unlike [gemvPacked] which always stages the weight into a fresh confined arena. This is
+     * what makes an off-heap-resident ternary weight (#1202's fix for the ART heap cap) actually
+     * fast on the row loop [sk.ainet.backend.api.kernel.NativeTernaryF32ViewKernel] runs, rather
+     * than falling back to re-copying the whole matrix on every row.
+     *
+     * Activation/output still stage through a small confined arena — they're `k`/`n` floats, not
+     * the weight matrix, so the cost is the same as [gemvPacked] pays today for those two.
+     */
+    @OptIn(ExperimentalMemoryApi::class)
+    override fun gemvPackedStorage(
+        activation: FloatArray, activationOffset: Int,
+        weight: Storage, weightByteOffset: Int,
+        inputDim: Int, outputDim: Int,
+        output: FloatArray, outputOffset: Int,
+    ) {
+        val weightSeg = (weight as? SegmentStorage)?.segment()
+        if (weightSeg == null) {
+            super.gemvPackedStorage(activation, activationOffset, weight, weightByteOffset, inputDim, outputDim, output, outputOffset)
+            return
+        }
+        require(inputDim % 4 == 0) {
+            "NativeTernaryF32GemvKernel: inputDim must be a multiple of 4; got $inputDim"
+        }
+        if (outputDim == 0) return
+
+        val mh = handle
+            ?: error("NativeTernaryF32GemvKernel.gemv invoked while native library unavailable")
+
+        val inputReachFloats = if (inputDim == 0) 0 else activationOffset + inputDim
+        val outputReachFloats = outputOffset + outputDim
+
+        Arena.ofConfined().use { arena ->
+            val fAlign = ValueLayout.JAVA_FLOAT.byteAlignment()
+
+            val inputSeg: MemorySegment = if (inputReachFloats > 0)
+                arena.allocate(inputReachFloats.toLong() * java.lang.Float.BYTES, fAlign)
+            else MemorySegment.NULL
+            val outputSeg: MemorySegment =
+                arena.allocate(outputReachFloats.toLong() * java.lang.Float.BYTES, fAlign)
+
+            if (inputReachFloats > 0) {
+                MemorySegment.copy(activation, 0, inputSeg, ValueLayout.JAVA_FLOAT, 0L, inputReachFloats)
+            }
+            MemorySegment.copy(output, 0, outputSeg, ValueLayout.JAVA_FLOAT, 0L, outputReachFloats)
+
+            mh.invoke(
+                inputSeg, activationOffset,
                 weightSeg, weightByteOffset,
                 inputDim, outputDim,
                 outputSeg, outputOffset,

--- a/skainet-backends/skainet-backend-native-cpu/src/jvmTest/kotlin/sk/ainet/exec/kernel/NativeTernaryF32GemvKernelTest.kt
+++ b/skainet-backends/skainet-backend-native-cpu/src/jvmTest/kotlin/sk/ainet/exec/kernel/NativeTernaryF32GemvKernelTest.kt
@@ -1,11 +1,15 @@
 package sk.ainet.exec.kernel
 
+import sk.ainet.lang.memory.ExperimentalMemoryApi
+import sk.ainet.lang.memory.SegmentStorage
+import sk.ainet.lang.memory.Storage
 import kotlin.math.abs
 import kotlin.random.Random
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 /**
@@ -169,5 +173,56 @@ class NativeTernaryF32GemvKernelTest {
             FloatArray(0), 0, ByteArray(0), 0, 0, 3, out, 0,
         )
         for (v in out) assertEquals(0f, v, "output should be zeroed for inputDim=0")
+    }
+
+    /**
+     * #1202: [NativeTernaryF32GemvKernel.gemvPackedStorage] against a [SegmentStorage]-backed
+     * weight must match [NativeTernaryF32GemvKernel.gemvPacked] on the identical bytes exactly —
+     * it's the same native call, just handed the weight's `MemorySegment` directly instead of a
+     * copy staged into a fresh arena.
+     */
+    @OptIn(ExperimentalMemoryApi::class)
+    @Test
+    fun gemvPackedStorage_matches_gemvPacked_on_a_segment_backed_weight() {
+        val inputDim = 2560
+        val outputDim = 64
+        val rng = Random(11)
+        val input = FloatArray(inputDim) { rng.nextFloat() - 0.5f }
+        val weightBytes = ByteArray(outputDim * inputDim / 4).also { rng.nextBytes(it) }
+
+        val expected = FloatArray(outputDim)
+        NativeTernaryF32GemvKernel.gemvPacked(input, 0, weightBytes, 0, inputDim, outputDim, expected, 0)
+
+        val segment = SegmentStorage.allocate(weightBytes.size.toLong())
+        try {
+            segment.copyFrom(weightBytes)
+            val viaStorage = FloatArray(outputDim)
+            NativeTernaryF32GemvKernel.gemvPackedStorage(input, 0, segment, 0, inputDim, outputDim, viaStorage, 0)
+            assertEquals(
+                expected.toList(), viaStorage.toList(),
+                "gemvPackedStorage over a SegmentStorage must equal gemvPacked over the same bytes",
+            )
+        } finally {
+            segment.close()
+        }
+    }
+
+    /** A storage kind the FFM face can't read directly (here: plain Heap) falls back correctly. */
+    @OptIn(ExperimentalMemoryApi::class)
+    @Test
+    fun gemvPackedStorage_falls_back_correctly_for_non_segment_storage() {
+        val inputDim = 256
+        val outputDim = 4
+        val rng = Random(5)
+        val input = FloatArray(inputDim) { rng.nextFloat() - 0.5f }
+        val weightBytes = ByteArray(outputDim * inputDim / 4).also { rng.nextBytes(it) }
+
+        val expected = FloatArray(outputDim)
+        NativeTernaryF32GemvKernel.gemvPacked(input, 0, weightBytes, 0, inputDim, outputDim, expected, 0)
+
+        val heap = assertIs<Storage.Heap>(Storage.Heap.wrap(weightBytes, mutable = false))
+        val viaFallback = FloatArray(outputDim)
+        NativeTernaryF32GemvKernel.gemvPackedStorage(input, 0, heap, 0, inputDim, outputDim, viaFallback, 0)
+        assertEquals(expected.toList(), viaFallback.toList())
     }
 }

--- a/skainet-io/skainet-io-gguf/src/commonMain/kotlin/sk/ainet/io/gguf/StreamingGgufParametersLoader.kt
+++ b/skainet-io/skainet-io-gguf/src/commonMain/kotlin/sk/ainet/io/gguf/StreamingGgufParametersLoader.kt
@@ -584,6 +584,7 @@ public class StreamingGgufParametersLoader(
      * defined against.
      */
     @Suppress("UNCHECKED_CAST")
+    @OptIn(sk.ainet.lang.memory.ExperimentalMemoryApi::class)
     private fun <T : DType, V> i2sTensor(
         ctx: ExecutionContext,
         dtype: KClass<T>,
@@ -627,8 +628,36 @@ public class StreamingGgufParametersLoader(
             )
             return ctx.wrapFloatArray<T, Float>(shape, dtype, dest) as Tensor<T, V>
         }
-        val packed = sk.ainet.lang.tensor.data.BitNetB158TensorData(shape, packedBytes)
+        val packed = i2sPackedTensorData(shape, packedBytes)
         return ctx.fromData(packed as sk.ainet.lang.tensor.data.TensorData<T, V>, dtype)
+    }
+
+    /**
+     * [packedBytes] as a [sk.ainet.lang.tensor.data.BitNetB158TensorData] — off the ART heap
+     * (#1202) when the payload is at least [sk.ainet.lang.memory.plan.PlannerProfile.OFF_HEAP_THRESHOLD]
+     * and the platform supports it; otherwise the historical heap-backed constructor.
+     *
+     * A 2B-parameter BitNet model's ternary weights are ~0.25 bytes/weight — roughly 500MB
+     * resident as plain `ByteArray`s, which alone can exceed Android's default ART heap cap. This
+     * is independent of *residency* (`WeightResidency.MAPPED` isn't reachable for a repacked
+     * payload — the bytes are no longer the file's own — see `AllocationResolver`): it's purely
+     * about not holding the repack's result in managed-heap memory once it's large enough to
+     * matter.
+     */
+    @OptIn(sk.ainet.lang.memory.ExperimentalMemoryApi::class)
+    private fun i2sPackedTensorData(shape: Shape, packedBytes: ByteArray): sk.ainet.lang.tensor.data.BitNetB158TensorData {
+        val offHeapThreshold = sk.ainet.lang.memory.plan.PlannerProfile.OFF_HEAP_THRESHOLD
+        if (packedBytes.size < offHeapThreshold || !sk.ainet.lang.memory.PlatformStorage.supports(sk.ainet.lang.tensor.storage.MemoryDomain.HOST_OFFHEAP)) {
+            return sk.ainet.lang.tensor.data.BitNetB158TensorData(shape, packedBytes)
+        }
+        val storage = sk.ainet.lang.memory.PlatformStorage.allocate(
+            bytes = packedBytes.size.toLong(),
+            domain = sk.ainet.lang.tensor.storage.MemoryDomain.HOST_OFFHEAP,
+            scope = sk.ainet.lang.memory.ScopeKind.MODEL,
+            sink = traceSink,
+        )
+        storage.copyFrom(packedBytes)
+        return sk.ainet.lang.tensor.data.BitNetB158TensorData.fromStorage(shape, storage)
     }
 
     /**

--- a/skainet-io/skainet-io-gguf/src/jvmTest/kotlin/sk/ainet/io/gguf/I2sOffHeapLoadTest.kt
+++ b/skainet-io/skainet-io-gguf/src/jvmTest/kotlin/sk/ainet/io/gguf/I2sOffHeapLoadTest.kt
@@ -1,0 +1,88 @@
+package sk.ainet.io.gguf
+
+import kotlinx.coroutines.runBlocking
+import sk.ainet.context.DefaultDataExecutionContext
+import sk.ainet.io.JvmRandomAccessSource
+import sk.ainet.lang.memory.ExperimentalMemoryApi
+import sk.ainet.lang.memory.Storage
+import sk.ainet.lang.memory.TernaryCodec
+import sk.ainet.lang.memory.plan.PlannerProfile
+import sk.ainet.lang.tensor.Tensor
+import sk.ainet.lang.tensor.data.BitNetB158TensorData
+import sk.ainet.lang.types.FP32
+import java.io.File
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertIs
+
+/**
+ * #1202: an I2_S payload at least [PlannerProfile.OFF_HEAP_THRESHOLD] bytes loads into off-heap
+ * storage instead of a permanent `ByteArray` — the fix for #1198's ART-heap-cap OOM risk — and
+ * decodes to exactly the same values a heap-backed load would produce.
+ */
+@OptIn(ExperimentalMemoryApi::class)
+class I2sOffHeapLoadTest {
+
+    /** BitNet.cpp's GROUP_128 packing + 32-byte trailer, sized to cross the off-heap threshold. */
+    private fun bitnetCppTensor(name: String, elements: Int, seed: Int, scale: Float): SyntheticGguf.TestTensor {
+        val rng = Random(seed)
+        val qk = 128
+        val bytesPerBlock = qk / 4
+        val payload = ByteArray(elements / 4)
+        for (j in 0 until elements) {
+            val jb = j % qk
+            val byteIndex = (j / qk) * bytesPerBlock + jb % bytesPerBlock
+            payload[byteIndex] = (payload[byteIndex].toInt() or (rng.nextInt(3) shl (6 - 2 * (jb / bytesPerBlock)))).toByte()
+        }
+        val trailer = ByteBuffer.allocate(32).order(ByteOrder.LITTLE_ENDIAN)
+        repeat(8) { trailer.putFloat(scale) }
+        return SyntheticGguf.TestTensor(name, GGMLQuantizationType.I2_S, elements.toLong(), payload + trailer.array())
+    }
+
+    private fun load(file: File): Tensor<FP32, Float> {
+        val ctx = DefaultDataExecutionContext()
+        var tensor: Tensor<FP32, Float>? = null
+        runBlocking {
+            StreamingGgufParametersLoader(sourceProvider = { JvmRandomAccessSource.open(file) })
+                .load<FP32, Float>(ctx, FP32::class) { _, t -> tensor = t }
+        }
+        return tensor!!
+    }
+
+    @Test
+    fun payloadAtTheThresholdLoadsOffHeapAndDecodesCorrectly() {
+        // payload = elements / 4 bytes; pick elements so the payload lands exactly at the
+        // threshold (a multiple of 128 for GROUP_128 blocking).
+        val elements = (PlannerProfile.OFF_HEAP_THRESHOLD * 4).toInt()
+        val file = SyntheticGguf.write(bitnetCppTensor("w", elements, seed = 3, scale = 0.25f))
+        try {
+            val packed = assertIs<BitNetB158TensorData>(load(file).data)
+            assertIs<Storage.OffHeap>(packed.packedStorage, "a $elements-element I2_S payload must not be a permanent heap array")
+
+            // The lazily-materialized snapshot must equal exactly what was written into
+            // off-heap storage — i.e. copyFrom (write) and copyInto (read) round-trip correctly
+            // through the real load path, not just in the Storage unit tests.
+            assertContentEquals(
+                TernaryCodec.decodeBitNet(packed.packedData, elements),
+                packed.toFloatArray(),
+            )
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun payloadBelowTheThresholdStaysOnHeap() {
+        val elements = 256 // well under the threshold
+        val file = SyntheticGguf.write(bitnetCppTensor("w", elements, seed = 3, scale = 0.25f))
+        try {
+            val packed = assertIs<BitNetB158TensorData>(load(file).data)
+            assertIs<Storage.Heap>(packed.packedStorage, "a tiny I2_S payload should stay on the heap, not pay an off-heap allocation")
+        } finally {
+            file.delete()
+        }
+    }
+}

--- a/skainet-lang/skainet-lang-core/api/jvm/skainet-lang-core.api
+++ b/skainet-lang/skainet-lang-core/api/jvm/skainet-lang-core.api
@@ -772,6 +772,8 @@ public final class sk/ainet/lang/memory/DirectBufferStorage : sk/ainet/lang/memo
 	public static final field Companion Lsk/ainet/lang/memory/DirectBufferStorage$Companion;
 	public synthetic fun <init> (JLjava/nio/ByteBuffer;Lsk/ainet/lang/memory/Owner;Lsk/ainet/lang/tensor/TensorId;Lsk/ainet/lang/memory/trace/TraceSink;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun buffer ()Ljava/nio/ByteBuffer;
+	public fun copyFrom ([BIJI)V
+	public fun copyInto ([BIJI)V
 	public fun getDebugOrigin ()Lsk/ainet/lang/tensor/TensorId;
 	public fun getId-TPZW6QE ()J
 	public fun getOwner ()Lsk/ainet/lang/memory/Owner;
@@ -892,6 +894,8 @@ public final class sk/ainet/lang/memory/MappedBufferStorage : sk/ainet/lang/memo
 	public static final field Companion Lsk/ainet/lang/memory/MappedBufferStorage$Companion;
 	public synthetic fun <init> (JLjava/nio/file/Path;JLjava/nio/ByteBuffer;Lsk/ainet/lang/memory/Owner;Lsk/ainet/lang/tensor/TensorId;Lsk/ainet/lang/memory/trace/TraceSink;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun buffer ()Ljava/nio/ByteBuffer;
+	public fun copyFrom ([BIJI)V
+	public fun copyInto ([BIJI)V
 	public fun getDebugOrigin ()Lsk/ainet/lang/tensor/TensorId;
 	public final fun getFileOffset ()J
 	public fun getId-TPZW6QE ()J
@@ -911,6 +915,8 @@ public final class sk/ainet/lang/memory/MappedBufferStorage$Companion {
 public final class sk/ainet/lang/memory/MappedFileStorage : sk/ainet/lang/memory/Storage$Mapped {
 	public static final field Companion Lsk/ainet/lang/memory/MappedFileStorage$Companion;
 	public synthetic fun <init> (JLjava/nio/file/Path;JLjava/lang/foreign/MemorySegment;Lsk/ainet/lang/memory/Owner;Lsk/ainet/lang/tensor/TensorId;Lsk/ainet/lang/memory/trace/TraceSink;Ljava/lang/foreign/Arena;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun copyFrom ([BIJI)V
+	public fun copyInto ([BIJI)V
 	public fun getDebugOrigin ()Lsk/ainet/lang/tensor/TensorId;
 	public final fun getFileOffset ()J
 	public fun getId-TPZW6QE ()J
@@ -1156,6 +1162,8 @@ public final class sk/ainet/lang/memory/ScopeKind : java/lang/Enum {
 public final class sk/ainet/lang/memory/SegmentStorage : sk/ainet/lang/memory/Storage$OffHeap {
 	public static final field Companion Lsk/ainet/lang/memory/SegmentStorage$Companion;
 	public synthetic fun <init> (JLjava/lang/foreign/MemorySegment;Lsk/ainet/lang/memory/Owner;Lsk/ainet/lang/tensor/TensorId;Lsk/ainet/lang/memory/trace/TraceSink;Ljava/lang/foreign/Arena;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun copyFrom ([BIJI)V
+	public fun copyInto ([BIJI)V
 	public fun getDebugOrigin ()Lsk/ainet/lang/tensor/TensorId;
 	public fun getId-TPZW6QE ()J
 	public fun getOwner ()Lsk/ainet/lang/memory/Owner;
@@ -1179,6 +1187,10 @@ public final class sk/ainet/lang/memory/SegmentStorage$Companion {
 public abstract class sk/ainet/lang/memory/Storage : java/lang/AutoCloseable {
 	public final fun checkAlive ()V
 	public final fun close ()V
+	public abstract fun copyFrom ([BIJI)V
+	public static synthetic fun copyFrom$default (Lsk/ainet/lang/memory/Storage;[BIJIILjava/lang/Object;)V
+	public abstract fun copyInto ([BIJI)V
+	public static synthetic fun copyInto$default (Lsk/ainet/lang/memory/Storage;[BIJIILjava/lang/Object;)V
 	public abstract fun getDebugOrigin ()Lsk/ainet/lang/tensor/TensorId;
 	public abstract fun getDomain ()Lsk/ainet/lang/tensor/storage/MemoryDomain;
 	public abstract fun getId-TPZW6QE ()J
@@ -1201,6 +1213,8 @@ public abstract class sk/ainet/lang/memory/Storage$Device : sk/ainet/lang/memory
 public final class sk/ainet/lang/memory/Storage$Heap : sk/ainet/lang/memory/Storage {
 	public static final field Companion Lsk/ainet/lang/memory/Storage$Heap$Companion;
 	public synthetic fun <init> (J[F[I[BIJLsk/ainet/lang/memory/Owner;Lsk/ainet/lang/tensor/TensorId;Lsk/ainet/lang/memory/trace/TraceSink;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun copyFrom ([BIJI)V
+	public fun copyInto ([BIJI)V
 	public final fun getArrayOffset ()I
 	public final fun getBytes ()[B
 	public fun getDebugOrigin ()Lsk/ainet/lang/tensor/TensorId;
@@ -4681,6 +4695,7 @@ public final class sk/ainet/lang/tensor/data/Bf16TensorDataKt {
 
 public final class sk/ainet/lang/tensor/data/BitNetB158TensorData : sk/ainet/lang/tensor/data/TensorData, sk/ainet/lang/tensor/storage/PackedBlockStorage {
 	public static final field Companion Lsk/ainet/lang/tensor/data/BitNetB158TensorData$Companion;
+	public fun <init> (Lsk/ainet/lang/tensor/Shape;Lsk/ainet/lang/memory/Storage;)V
 	public fun <init> (Lsk/ainet/lang/tensor/Shape;[B)V
 	public fun copyToFloatArray ()[F
 	public fun dequantizeBlock (I[FI)V
@@ -4692,6 +4707,7 @@ public final class sk/ainet/lang/tensor/data/BitNetB158TensorData : sk/ainet/lan
 	public fun getElementCount ()J
 	public fun getEncoding ()Lsk/ainet/lang/tensor/storage/TensorEncoding;
 	public fun getPackedData ()[B
+	public fun getPackedStorage ()Lsk/ainet/lang/memory/Storage;
 	public fun getPackedView ()Lsk/ainet/lang/memory/TensorView;
 	public fun getPhysicalBytes ()J
 	public final fun getScale ()F
@@ -4707,6 +4723,7 @@ public final class sk/ainet/lang/tensor/data/BitNetB158TensorData : sk/ainet/lan
 public final class sk/ainet/lang/tensor/data/BitNetB158TensorData$Companion {
 	public final fun fromFloats (Lsk/ainet/lang/tensor/Shape;[F)Lsk/ainet/lang/tensor/data/BitNetB158TensorData;
 	public final fun fromRawBytes (Lsk/ainet/lang/tensor/Shape;[B)Lsk/ainet/lang/tensor/data/BitNetB158TensorData;
+	public final fun fromStorage (Lsk/ainet/lang/tensor/Shape;Lsk/ainet/lang/memory/Storage;)Lsk/ainet/lang/tensor/data/BitNetB158TensorData;
 }
 
 public final class sk/ainet/lang/tensor/data/BitNetPlanesTensorData : sk/ainet/lang/tensor/data/TensorData, sk/ainet/lang/tensor/storage/PackedBlockStorage {
@@ -4723,6 +4740,7 @@ public final class sk/ainet/lang/tensor/data/BitNetPlanesTensorData : sk/ainet/l
 	public fun getElementCount ()J
 	public fun getEncoding ()Lsk/ainet/lang/tensor/storage/TensorEncoding;
 	public fun getPackedData ()[B
+	public fun getPackedStorage ()Lsk/ainet/lang/memory/Storage;
 	public fun getPackedView ()Lsk/ainet/lang/memory/TensorView;
 	public fun getPhysicalBytes ()J
 	public final fun getRows ()I
@@ -4753,6 +4771,7 @@ public final class sk/ainet/lang/tensor/data/BufferPackedTensorData : sk/ainet/l
 	public fun getElementCount ()J
 	public fun getEncoding ()Lsk/ainet/lang/tensor/storage/TensorEncoding;
 	public fun getPackedData ()[B
+	public fun getPackedStorage ()Lsk/ainet/lang/memory/Storage;
 	public fun getPackedView ()Lsk/ainet/lang/memory/TensorView;
 	public fun getPhysicalBytes ()J
 	public fun getShape ()Lsk/ainet/lang/tensor/Shape;
@@ -5082,6 +5101,7 @@ public final class sk/ainet/lang/tensor/data/Q4_0BlockTensorData : sk/ainet/lang
 	public fun getElementCount ()J
 	public fun getEncoding ()Lsk/ainet/lang/tensor/storage/TensorEncoding;
 	public fun getPackedData ()[B
+	public fun getPackedStorage ()Lsk/ainet/lang/memory/Storage;
 	public fun getPackedView ()Lsk/ainet/lang/memory/TensorView;
 	public fun getPhysicalBytes ()J
 	public fun getShape ()Lsk/ainet/lang/tensor/Shape;
@@ -5145,6 +5165,7 @@ public final class sk/ainet/lang/tensor/data/Q4_KBlockTensorData : sk/ainet/lang
 	public fun getElementCount ()J
 	public fun getEncoding ()Lsk/ainet/lang/tensor/storage/TensorEncoding;
 	public fun getPackedData ()[B
+	public fun getPackedStorage ()Lsk/ainet/lang/memory/Storage;
 	public fun getPackedView ()Lsk/ainet/lang/memory/TensorView;
 	public fun getPhysicalBytes ()J
 	public fun getShape ()Lsk/ainet/lang/tensor/Shape;
@@ -5208,6 +5229,7 @@ public final class sk/ainet/lang/tensor/data/Q5_0BlockTensorData : sk/ainet/lang
 	public fun getElementCount ()J
 	public fun getEncoding ()Lsk/ainet/lang/tensor/storage/TensorEncoding;
 	public fun getPackedData ()[B
+	public fun getPackedStorage ()Lsk/ainet/lang/memory/Storage;
 	public fun getPackedView ()Lsk/ainet/lang/memory/TensorView;
 	public fun getPhysicalBytes ()J
 	public fun getShape ()Lsk/ainet/lang/tensor/Shape;
@@ -5256,6 +5278,7 @@ public final class sk/ainet/lang/tensor/data/Q5_1BlockTensorData : sk/ainet/lang
 	public fun getElementCount ()J
 	public fun getEncoding ()Lsk/ainet/lang/tensor/storage/TensorEncoding;
 	public fun getPackedData ()[B
+	public fun getPackedStorage ()Lsk/ainet/lang/memory/Storage;
 	public fun getPackedView ()Lsk/ainet/lang/memory/TensorView;
 	public fun getPhysicalBytes ()J
 	public fun getShape ()Lsk/ainet/lang/tensor/Shape;
@@ -5307,6 +5330,7 @@ public final class sk/ainet/lang/tensor/data/Q5_KBlockTensorData : sk/ainet/lang
 	public fun getElementCount ()J
 	public fun getEncoding ()Lsk/ainet/lang/tensor/storage/TensorEncoding;
 	public fun getPackedData ()[B
+	public fun getPackedStorage ()Lsk/ainet/lang/memory/Storage;
 	public fun getPackedView ()Lsk/ainet/lang/memory/TensorView;
 	public fun getPhysicalBytes ()J
 	public fun getShape ()Lsk/ainet/lang/tensor/Shape;
@@ -5376,6 +5400,7 @@ public final class sk/ainet/lang/tensor/data/Q6_KBlockTensorData : sk/ainet/lang
 	public fun getElementCount ()J
 	public fun getEncoding ()Lsk/ainet/lang/tensor/storage/TensorEncoding;
 	public fun getPackedData ()[B
+	public fun getPackedStorage ()Lsk/ainet/lang/memory/Storage;
 	public fun getPackedView ()Lsk/ainet/lang/memory/TensorView;
 	public fun getPhysicalBytes ()J
 	public fun getShape ()Lsk/ainet/lang/tensor/Shape;
@@ -5468,6 +5493,7 @@ public final class sk/ainet/lang/tensor/data/Q8_0BlockTensorData : sk/ainet/lang
 	public fun getElementCount ()J
 	public fun getEncoding ()Lsk/ainet/lang/tensor/storage/TensorEncoding;
 	public fun getPackedData ()[B
+	public fun getPackedStorage ()Lsk/ainet/lang/memory/Storage;
 	public fun getPackedView ()Lsk/ainet/lang/memory/TensorView;
 	public fun getPhysicalBytes ()J
 	public fun getShape ()Lsk/ainet/lang/tensor/Shape;
@@ -5605,6 +5631,7 @@ public final class sk/ainet/lang/tensor/data/Ternary2BitTensorData : sk/ainet/la
 	public fun getElementCount ()J
 	public fun getEncoding ()Lsk/ainet/lang/tensor/storage/TensorEncoding;
 	public fun getPackedData ()[B
+	public fun getPackedStorage ()Lsk/ainet/lang/memory/Storage;
 	public fun getPackedView ()Lsk/ainet/lang/memory/TensorView;
 	public fun getPhysicalBytes ()J
 	public fun getScale ()F
@@ -7399,6 +7426,7 @@ public abstract interface class sk/ainet/lang/tensor/storage/PackedBlockStorage 
 	public fun getElementCount ()J
 	public abstract fun getEncoding ()Lsk/ainet/lang/tensor/storage/TensorEncoding;
 	public abstract fun getPackedData ()[B
+	public fun getPackedStorage ()Lsk/ainet/lang/memory/Storage;
 	public fun getPackedView ()Lsk/ainet/lang/memory/TensorView;
 	public fun getPhysicalBytes ()J
 	public abstract fun getShape ()Lsk/ainet/lang/tensor/Shape;
@@ -7413,6 +7441,7 @@ public final class sk/ainet/lang/tensor/storage/PackedBlockStorage$DefaultImpls 
 	public static synthetic fun dequantizeBlock$default (Lsk/ainet/lang/tensor/storage/PackedBlockStorage;I[FIILjava/lang/Object;)V
 	public static fun getBlockOrder (Lsk/ainet/lang/tensor/storage/PackedBlockStorage;)Lsk/ainet/lang/memory/BlockOrder;
 	public static fun getElementCount (Lsk/ainet/lang/tensor/storage/PackedBlockStorage;)J
+	public static fun getPackedStorage (Lsk/ainet/lang/tensor/storage/PackedBlockStorage;)Lsk/ainet/lang/memory/Storage;
 	public static fun getPackedView (Lsk/ainet/lang/tensor/storage/PackedBlockStorage;)Lsk/ainet/lang/memory/TensorView;
 	public static fun getPhysicalBytes (Lsk/ainet/lang/tensor/storage/PackedBlockStorage;)J
 	public static fun toFloatArray (Lsk/ainet/lang/tensor/storage/PackedBlockStorage;)[F

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/memory/Storage.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/memory/Storage.kt
@@ -123,6 +123,22 @@ public sealed class Storage : AutoCloseable {
     /** A zero-copy alias over `[offsetBytes, offsetBytes + lengthBytes)` of this storage. */
     public abstract fun slice(offsetBytes: Long, lengthBytes: Long): Storage
 
+    /**
+     * Copy [length] bytes starting at [offset] into [dest] starting at [destOffset] — the one
+     * primitive that reads packed bytes uniformly regardless of storage kind (#1202). A kernel or
+     * decoder that only has a [ByteArray]-shaped contract (native FFM/JNI calls, [TernaryCodec])
+     * uses this to get a transient snapshot out of [OffHeap]/[Mapped] storage; for [Heap] it is a
+     * plain array copy, no snapshot needed.
+     */
+    public abstract fun copyInto(dest: ByteArray, destOffset: Int = 0, offset: Long = 0, length: Int = dest.size - destOffset)
+
+    /**
+     * Copy [length] bytes from [src] starting at [srcOffset] into this storage starting at
+     * [offset] — the inverse of [copyInto], e.g. writing a repacked payload into freshly
+     * allocated off-heap storage. Requires [isMutable].
+     */
+    public abstract fun copyFrom(src: ByteArray, srcOffset: Int = 0, offset: Long = 0, length: Int = src.size - srcOffset)
+
     override fun toString(): String = "${this::class.simpleName}(${id}, ${sizeBytes} B, $owner, $domain${debugOrigin?.let { ", $it" } ?: ""}${if (isAlive) "" else ", closed"})"
 
     /**
@@ -158,6 +174,21 @@ public sealed class Storage : AutoCloseable {
             require(offsetBytes >= 0 && lengthBytes >= 0 && offsetBytes + lengthBytes <= sizeBytes) { "slice [$offsetBytes, ${offsetBytes + lengthBytes}) outside $sizeBytes bytes" }
             require(offsetBytes % elementBytes == 0L && lengthBytes % elementBytes == 0L) { "slice must align to $elementBytes-byte elements" }
             return Heap(StorageId.next(), floats, ints, bytes, arrayOffset + (offsetBytes / elementBytes).toInt(), lengthBytes, Owner.Alias(this), debugOrigin, sink, mutable)
+        }
+
+        override fun copyInto(dest: ByteArray, destOffset: Int, offset: Long, length: Int) {
+            checkAlive()
+            val b = bytes ?: throw UnsupportedOperationException("copyInto needs byte-backed Heap storage")
+            val start = arrayOffset + offset.toInt()
+            b.copyInto(dest, destOffset, start, start + length)
+        }
+
+        override fun copyFrom(src: ByteArray, srcOffset: Int, offset: Long, length: Int) {
+            checkAlive()
+            require(isMutable) { "storage $id is not mutable" }
+            val b = bytes ?: throw UnsupportedOperationException("copyFrom needs byte-backed Heap storage")
+            val start = arrayOffset + offset.toInt()
+            src.copyInto(b, start, srcOffset, srcOffset + length)
         }
 
         public companion object {

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/data/BitNetB158TensorData.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/data/BitNetB158TensorData.kt
@@ -1,5 +1,7 @@
 package sk.ainet.lang.tensor.data
 
+import sk.ainet.lang.memory.ExperimentalMemoryApi
+import sk.ainet.lang.memory.Storage
 import sk.ainet.lang.memory.TernaryCodec
 import sk.ainet.lang.tensor.Shape
 import sk.ainet.lang.tensor.storage.PackedBlockStorage
@@ -21,10 +23,26 @@ import sk.ainet.lang.types.DType
  * serves (#1138). `get` returns the *signed code* (−1, 0, +1; byte code 3 → +2), scale not
  * applied; decoding with the scale goes through [dequantizeBlock] / [PackedBlockStorage.toFloatArray].
  */
-public class BitNetB158TensorData(
+public class BitNetB158TensorData private constructor(
     initialShape: Shape,
-    private val data: ByteArray,
+    private val heapData: ByteArray?,
+    private val backingStorage: Storage?,
 ) : TensorData<DType, Byte>, PackedBlockStorage {
+
+    /** Wrap raw `payload + scale` bytes on the JVM/heap — the historical constructor. */
+    public constructor(initialShape: Shape, data: ByteArray) : this(initialShape, data, null)
+
+    /**
+     * Wrap [storage]-backed `payload + scale` bytes (#1202) — off-heap or mapped storage large
+     * enough that a permanent heap-resident copy would count against Android's ART heap cap.
+     * [PackedBlockStorage.packedView] (and so the GEMV kernels) read [storage] directly; the
+     * per-element accessors below ([codeAt], [get], [set], [scale], [dequantizeBlock]) are a
+     * slower path that lazily snapshots [storage] into a transient heap array on first use —
+     * they are not on the fast kernel-dispatch path, so that snapshot is the exception, not the
+     * steady state.
+     */
+    @ExperimentalMemoryApi
+    public constructor(initialShape: Shape, storage: Storage) : this(initialShape, null, storage)
 
     /** The façade over the packed bytes (SKEEP-003 §4.1): see [PackedBlockStorage.packedView]. */
     @sk.ainet.lang.memory.ExperimentalMemoryApi
@@ -36,16 +54,31 @@ public class BitNetB158TensorData(
     override val encoding: TensorEncoding get() = TensorEncoding.BITNET_B1_58
     override val blockCount: Int get() = 1
     override val blockSize: Int get() = shape.volume
+
+    @ExperimentalMemoryApi
+    override val packedStorage: Storage
+        get() = backingStorage ?: Storage.Heap.wrap(heapData!!, mutable = false)
+
+    /**
+     * Lazily materialized heap snapshot of [backingStorage] — [packedData]/[codeAt]/[get]/[set]
+     * only, never the kernel dispatch path (that reads [packedStorage] directly). Computed once;
+     * a tensor that's only ever used for inference through the GEMV kernels never triggers this.
+     */
+    private val data: ByteArray by lazy(LazyThreadSafetyMode.NONE) {
+        heapData ?: ByteArray(backingStorage!!.sizeBytes.toInt()).also { backingStorage.copyInto(it) }
+    }
+
     override val packedData: ByteArray get() = data
 
     /** The per-tensor FP32 scale (the trailing 4 bytes). */
     public val scale: Float get() = TernaryCodec.bitNetScale(data, shape.volume)
 
     init {
+        val sizeBytes = heapData?.size?.toLong() ?: backingStorage!!.sizeBytes
         val required = (TensorEncoding.BITNET_B1_58.physicalBytes(shape.volume.toLong())
             ?: error("BITNET_B1_58 cannot size ${shape.volume} elements"))
-        require(data.size >= required) {
-            "BitNetB158TensorData: buffer is ${data.size} bytes, need >= $required " +
+        require(sizeBytes >= required) {
+            "BitNetB158TensorData: buffer is $sizeBytes bytes, need >= $required " +
                 "(ceil(${shape.volume}/4) payload + 4-byte FP32 scale)"
         }
     }
@@ -72,7 +105,11 @@ public class BitNetB158TensorData(
         val byteIndex = flatIndex / 4
         val shift = (flatIndex % 4) * 2
         val cleared = data[byteIndex].toInt() and (3 shl shift).inv()
-        data[byteIndex] = (cleared or ((value + 1) shl shift)).toByte()
+        val updated = (cleared or ((value + 1) shl shift)).toByte()
+        data[byteIndex] = updated
+        // The lazy snapshot above is a copy, not an alias, when backed by off-heap/mapped
+        // storage — write the single changed byte back so the two never diverge.
+        backingStorage?.copyFrom(byteArrayOf(updated), offset = byteIndex.toLong(), length = 1)
     }
 
     private fun calcFlatIndex(indices: IntArray): Int {
@@ -94,6 +131,11 @@ public class BitNetB158TensorData(
         /** Wrap raw `payload + scale` bytes (validates the size). */
         public fun fromRawBytes(shape: Shape, bytes: ByteArray): BitNetB158TensorData =
             BitNetB158TensorData(shape, bytes)
+
+        /** Wrap a `payload + scale` [storage] (validates the size) — see the [Storage] constructor. */
+        @ExperimentalMemoryApi
+        public fun fromStorage(shape: Shape, storage: Storage): BitNetB158TensorData =
+            BitNetB158TensorData(shape, storage)
 
         /** Encode [values] with [TernaryCodec.encodeBitNet] (absmean ternarization). */
         public fun fromFloats(shape: Shape, values: FloatArray): BitNetB158TensorData {

--- a/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/storage/PackedBlockStorage.kt
+++ b/skainet-lang/skainet-lang-core/src/commonMain/kotlin/sk/ainet/lang/tensor/storage/PackedBlockStorage.kt
@@ -33,6 +33,18 @@ public interface PackedBlockStorage {
     public val packedData: ByteArray
 
     /**
+     * The [sk.ainet.lang.memory.Storage] backing [packedData] (#1202).
+     *
+     * Defaults to wrapping [packedData] in [sk.ainet.lang.memory.Storage.Heap] — the historical
+     * behavior, unchanged for every implementer that doesn't override this. An implementer whose
+     * bytes actually live off-heap or mapped (e.g. a large ternary weight, to stay off the ART
+     * heap cap) overrides this to expose its real backing storage instead.
+     */
+    @sk.ainet.lang.memory.ExperimentalMemoryApi
+    public val packedStorage: sk.ainet.lang.memory.Storage
+        get() = sk.ainet.lang.memory.Storage.Heap.wrap(packedData, mutable = false)
+
+    /**
      * The order [packedData]'s blocks are physically in (#1120, #1124).
      *
      * Canonical storage — every GGUF-shaped producer — is
@@ -84,7 +96,7 @@ public interface PackedBlockStorage {
     @sk.ainet.lang.memory.ExperimentalMemoryApi
     public val packedView: sk.ainet.lang.memory.TensorView
         get() = sk.ainet.lang.memory.TensorView.packed(
-            storage = sk.ainet.lang.memory.Storage.Heap.wrap(packedData, mutable = false),
+            storage = packedStorage,
             shape = shape,
             encoding = encoding,
             decoder = sk.ainet.lang.memory.PackedBlockDecoder(this),

--- a/skainet-lang/skainet-lang-core/src/jvmAndroidMain/kotlin/sk/ainet/lang/memory/DirectBufferStorage.kt
+++ b/skainet-lang/skainet-lang-core/src/jvmAndroidMain/kotlin/sk/ainet/lang/memory/DirectBufferStorage.kt
@@ -41,6 +41,21 @@ public class DirectBufferStorage private constructor(
         return DirectBufferStorage(StorageId.next(), s, Owner.Alias(this), debugOrigin, sink)
     }
 
+    override fun copyInto(dest: ByteArray, destOffset: Int, offset: Long, length: Int) {
+        checkAlive()
+        val d: ByteBuffer = buf.duplicate()
+        d.position(offset.toInt())
+        d.get(dest, destOffset, length)
+    }
+
+    override fun copyFrom(src: ByteArray, srcOffset: Int, offset: Long, length: Int) {
+        checkAlive()
+        require(isMutable) { "storage $id is not mutable" }
+        val d: ByteBuffer = buf.duplicate()
+        d.position(offset.toInt())
+        d.put(src, srcOffset, length)
+    }
+
     public companion object {
         /** Allocate [bytes] zeroed direct bytes owned by a scope of kind [scope]. */
         public fun allocate(bytes: Int, scope: ScopeKind = ScopeKind.AMBIENT, origin: TensorId? = null, sink: TraceSink = NoopTraceSink): DirectBufferStorage {
@@ -83,6 +98,21 @@ public class MappedBufferStorage private constructor(
         d.position(offsetBytes.toInt()); d.limit((offsetBytes + lengthBytes).toInt())
         val s: ByteBuffer = d.slice().order(ByteOrder.LITTLE_ENDIAN)
         return MappedBufferStorage(StorageId.next(), path, fileOffset + offsetBytes, s, Owner.Alias(this), debugOrigin, sink)
+    }
+
+    override fun copyInto(dest: ByteArray, destOffset: Int, offset: Long, length: Int) {
+        checkAlive()
+        val d: ByteBuffer = buf.duplicate()
+        d.position(offset.toInt())
+        d.get(dest, destOffset, length)
+    }
+
+    override fun copyFrom(src: ByteArray, srcOffset: Int, offset: Long, length: Int) {
+        checkAlive()
+        require(isMutable) { "storage $id is not mutable" }
+        val d: ByteBuffer = buf.duplicate()
+        d.position(offset.toInt())
+        d.put(src, srcOffset, length)
     }
 
     public companion object {

--- a/skainet-lang/skainet-lang-core/src/jvmMain/kotlin/sk/ainet/lang/memory/JvmStorage.kt
+++ b/skainet-lang/skainet-lang-core/src/jvmMain/kotlin/sk/ainet/lang/memory/JvmStorage.kt
@@ -40,6 +40,17 @@ public class SegmentStorage private constructor(
         return SegmentStorage(StorageId.next(), seg.asSlice(offsetBytes, lengthBytes), Owner.Alias(this), debugOrigin, sink, null, mutable)
     }
 
+    override fun copyInto(dest: ByteArray, destOffset: Int, offset: Long, length: Int) {
+        checkAlive()
+        MemorySegment.copy(seg, ValueLayout.JAVA_BYTE, offset, dest, destOffset, length)
+    }
+
+    override fun copyFrom(src: ByteArray, srcOffset: Int, offset: Long, length: Int) {
+        checkAlive()
+        require(isMutable) { "storage $id is not mutable" }
+        MemorySegment.copy(src, srcOffset, seg, ValueLayout.JAVA_BYTE, offset, length)
+    }
+
     override fun onClose() { ownedArena?.close() }
 
     public companion object {
@@ -96,6 +107,17 @@ public class MappedFileStorage private constructor(
         checkAlive()
         require(offsetBytes >= 0 && lengthBytes >= 0 && offsetBytes + lengthBytes <= sizeBytes) { "slice [$offsetBytes, ${offsetBytes + lengthBytes}) outside $sizeBytes bytes" }
         return MappedFileStorage(StorageId.next(), path, fileOffset + offsetBytes, seg.asSlice(offsetBytes, lengthBytes), Owner.Alias(this), debugOrigin, sink, null)
+    }
+
+    override fun copyInto(dest: ByteArray, destOffset: Int, offset: Long, length: Int) {
+        checkAlive()
+        MemorySegment.copy(seg, ValueLayout.JAVA_BYTE, offset, dest, destOffset, length)
+    }
+
+    override fun copyFrom(src: ByteArray, srcOffset: Int, offset: Long, length: Int) {
+        checkAlive()
+        require(isMutable) { "storage $id is not mutable" }
+        MemorySegment.copy(src, srcOffset, seg, ValueLayout.JAVA_BYTE, offset, length)
     }
 
     override fun onClose() { arena?.close() }

--- a/skainet-lang/skainet-lang-core/src/jvmTest/kotlin/sk/ainet/lang/memory/PlatformStorageJvmTest.kt
+++ b/skainet-lang/skainet-lang-core/src/jvmTest/kotlin/sk/ainet/lang/memory/PlatformStorageJvmTest.kt
@@ -3,6 +3,7 @@ package sk.ainet.lang.memory
 import sk.ainet.lang.tensor.storage.MemoryDomain
 import java.nio.file.Files
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
@@ -17,5 +18,32 @@ class PlatformStorageJvmTest {
         assertIs<MappedFileStorage>(m); assertEquals(16L, m.sizeBytes); assertEquals(8.toByte(), m.segment().get(java.lang.foreign.ValueLayout.JAVA_BYTE, 0))
         m.close()
         assertEquals("OffHeap=MemorySegment (FFM) · Mapped=FileChannel.map → MemorySegment", PlatformStorage.info.toString())
+    }
+
+    @Test
+    fun copyIntoAndCopyFromRoundTripOnSegmentStorage() {
+        val storage = PlatformStorage.allocate(8, MemoryDomain.HOST_OFFHEAP)
+        val written = ByteArray(8) { (it + 1).toByte() }
+        storage.copyFrom(written)
+        val readBack = ByteArray(8)
+        storage.copyInto(readBack)
+        assertContentEquals(written, readBack)
+
+        // Partial, offset copies agree too.
+        val partial = ByteArray(3)
+        storage.copyInto(partial, offset = 2, length = 3)
+        assertContentEquals(byteArrayOf(3, 4, 5), partial)
+        storage.close()
+    }
+
+    @Test
+    fun copyIntoReadsMappedFileBytes() {
+        val f = Files.createTempFile("skainet-ps-copy", ".bin"); f.toFile().deleteOnExit()
+        Files.write(f, ByteArray(16) { it.toByte() })
+        val mapped = PlatformStorage.mapFile(f.toString(), 4, 8)
+        val out = ByteArray(8)
+        mapped.copyInto(out)
+        assertContentEquals(ByteArray(8) { (it + 4).toByte() }, out)
+        mapped.close()
     }
 }

--- a/skainet-lang/skainet-lang-core/src/jvmTest/kotlin/sk/ainet/lang/tensor/data/BitNetB158TensorDataJvmTest.kt
+++ b/skainet-lang/skainet-lang-core/src/jvmTest/kotlin/sk/ainet/lang/tensor/data/BitNetB158TensorDataJvmTest.kt
@@ -1,0 +1,65 @@
+package sk.ainet.lang.tensor.data
+
+import sk.ainet.lang.memory.ExperimentalMemoryApi
+import sk.ainet.lang.memory.PlatformStorage
+import sk.ainet.lang.memory.TernaryCodec
+import sk.ainet.lang.tensor.Shape
+import sk.ainet.lang.tensor.storage.MemoryDomain
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+/**
+ * #1202: an off-heap-backed [BitNetB158TensorData] must decode bit-for-bit identically to the
+ * historical heap-backed one, and [BitNetB158TensorData.set] must write through to the backing
+ * storage rather than only updating the lazily materialized snapshot.
+ */
+@OptIn(ExperimentalMemoryApi::class)
+class BitNetB158TensorDataJvmTest {
+
+    private fun ternaryValues(count: Int, seed: Int): FloatArray {
+        var s = seed
+        return FloatArray(count) {
+            s = s * 1103515245 + 12345
+            ((s ushr 16) % 3 - 1) * 0.5f
+        }
+    }
+
+    @Test
+    fun offHeapStorageDecodesIdenticallyToHeap() {
+        val n = 6; val k = 32
+        val values = ternaryValues(n * k, seed = 5)
+        val bytes = TernaryCodec.encodeBitNet(values)
+        val heap = BitNetB158TensorData(Shape(n, k), bytes)
+
+        val storage = PlatformStorage.allocate(bytes.size.toLong(), MemoryDomain.HOST_OFFHEAP)
+        storage.copyFrom(bytes)
+        val offHeap = BitNetB158TensorData.fromStorage(Shape(n, k), storage)
+
+        assertEquals(heap.scale, offHeap.scale)
+        assertContentEquals(heap.toFloatArray(), offHeap.toFloatArray())
+        assertContentEquals(heap.packedData, offHeap.packedData)
+        assertEquals(heap.get(1, 1), offHeap.get(1, 1))
+        assertIs<sk.ainet.lang.memory.Storage.OffHeap>(offHeap.packedStorage)
+        storage.close()
+    }
+
+    @Test
+    fun setWritesThroughToBackingStorage() {
+        val values = floatArrayOf(1f, -1f, 0f, 1f, -1f, 0f, 0f, 1f)
+        val bytes = TernaryCodec.encodeBitNet(values)
+        val storage = PlatformStorage.allocate(bytes.size.toLong(), MemoryDomain.HOST_OFFHEAP)
+        storage.copyFrom(bytes)
+        val offHeap = BitNetB158TensorData.fromStorage(Shape(8), storage)
+
+        offHeap.set(2, value = -1)
+        assertEquals(-1, offHeap.get(2).toInt())
+
+        // A second view constructed straight from the same storage — not the same Kotlin object,
+        // no shared lazy snapshot — must see the write, proving it reached the storage itself.
+        val reread = BitNetB158TensorData.fromStorage(Shape(8), storage)
+        assertEquals(-1, reread.get(2).toInt())
+        storage.close()
+    }
+}

--- a/skainet-lang/skainet-lang-core/src/nativeMain/kotlin/sk/ainet/lang/memory/NativeStorage.kt
+++ b/skainet-lang/skainet-lang-core/src/nativeMain/kotlin/sk/ainet/lang/memory/NativeStorage.kt
@@ -3,8 +3,10 @@
 package sk.ainet.lang.memory
 
 import kotlinx.cinterop.COpaquePointer
+import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.convert
 import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.usePinned
 import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.ByteVar
 import sk.ainet.lang.memory.trace.NoopTraceSink
@@ -19,6 +21,7 @@ import platform.posix.PROT_READ
 import platform.posix.close
 import platform.posix.free
 import platform.posix.malloc
+import platform.posix.memcpy
 import platform.posix.memset
 import platform.posix.mmap
 import platform.posix.munmap
@@ -48,6 +51,19 @@ public class NativeMallocStorage private constructor(
         checkAlive()
         require(offsetBytes >= 0 && lengthBytes >= 0 && offsetBytes + lengthBytes <= sizeBytes) { "slice [$offsetBytes, ${offsetBytes + lengthBytes}) outside $sizeBytes bytes" }
         return NativeMallocStorage(StorageId.next(), (ptr.rawValue + offsetBytes).toLong().toCPointer(), lengthBytes, Owner.Alias(this), debugOrigin, sink, mutable)
+    }
+
+    override fun copyInto(dest: ByteArray, destOffset: Int, offset: Long, length: Int) {
+        checkAlive()
+        val src = (ptr.rawValue + offset).toLong().toCPointer()
+        dest.usePinned { pinned -> memcpy(pinned.addressOf(destOffset), src, length.convert()) }
+    }
+
+    override fun copyFrom(src: ByteArray, srcOffset: Int, offset: Long, length: Int) {
+        checkAlive()
+        require(isMutable) { "storage $id is not mutable" }
+        val dst = (ptr.rawValue + offset).toLong().toCPointer()
+        src.usePinned { pinned -> memcpy(dst, pinned.addressOf(srcOffset), length.convert()) }
     }
 
     override fun onClose() { if (owner is Owner.Owned) free(ptr) }
@@ -90,6 +106,19 @@ public class NativeMappedStorage private constructor(
         checkAlive()
         require(offsetBytes >= 0 && lengthBytes >= 0 && offsetBytes + lengthBytes <= sizeBytes) { "slice [$offsetBytes, ${offsetBytes + lengthBytes}) outside $sizeBytes bytes" }
         return NativeMappedStorage(StorageId.next(), path, fileOffset + offsetBytes, base, (ptr.rawValue + offsetBytes).toLong().toCPointer(), lengthBytes, 0L, Owner.Alias(this), debugOrigin, sink)
+    }
+
+    override fun copyInto(dest: ByteArray, destOffset: Int, offset: Long, length: Int) {
+        checkAlive()
+        val src = (ptr.rawValue + offset).toLong().toCPointer()
+        dest.usePinned { pinned -> memcpy(pinned.addressOf(destOffset), src, length.convert()) }
+    }
+
+    override fun copyFrom(src: ByteArray, srcOffset: Int, offset: Long, length: Int) {
+        checkAlive()
+        require(isMutable) { "storage $id is not mutable" }
+        val dst = (ptr.rawValue + offset).toLong().toCPointer()
+        src.usePinned { pinned -> memcpy(dst, pinned.addressOf(srcOffset), length.convert()) }
     }
 
     override fun onClose() { if (owner is Owner.Owned) munmap(base, mappedLength.convert()) }


### PR DESCRIPTION
Closes #1202 (a sub-issue tracked under #1198).

## Problem

BitNet/ternary weights were held as permanent JVM heap `ByteArray`s regardless
of size, counted against Android's ART per-app heap cap — a 2B-parameter
model's ~500MB of ternary weights alone can exceed it. Independent of any
sidecar caching (#1198/#1204), since caching only avoids re-running the
repack, not the heap residency of its result.

## What this PR does

**Commit 1 — off-heap storage:**
- `Storage` gains `copyInto`/`copyFrom` bulk byte primitives, implemented for
  every concrete storage kind (`Heap`, `SegmentStorage`, `MappedFileStorage`,
  `DirectBufferStorage`, `MappedBufferStorage`, `NativeMallocStorage`,
  `NativeMappedStorage`).
- `PackedBlockStorage` gains a `packedStorage` property (defaults to wrapping
  `packedData` in `Storage.Heap`, so every existing quantized format is
  unaffected); `packedView` reads from it instead of always re-wrapping the
  raw array.
- `BitNetB158TensorData` gains a `Storage`-backed constructor/`fromStorage()`
  factory. The per-element accessors lazily snapshot off-heap storage into a
  transient array only if actually touched — inference through the GEMV
  kernels never triggers it.
- `StreamingGgufParametersLoader.i2sTensor()`: repacked I2_S payloads at or
  above `PlannerProfile.OFF_HEAP_THRESHOLD` (256KB) now allocate via
  `PlatformStorage.allocate(HOST_OFFHEAP)` instead of a permanent `ByteArray`.
- `BitNetGemvKernel`/`TernaryF32GemvKernel` (the reference/fallback kernels)
  widened to accept off-heap storage via a transient per-call snapshot.

**Commit 2 — zero-copy native fast path:**
The first commit's off-heap weights were correctly, but silently, falling
back to the slow Kotlin reference kernel on the fast NEON/FFM dispatch path.
Fixing that also surfaced a pre-existing, storage-independent inefficiency:
`NativeTernaryF32GemvKernel.gemvPacked` re-copies the *entire* weight matrix
into a fresh confined `Arena` on every single call, and the JVM wrapper calls
it once per activation row — so a multi-row prefill was already re-copying
the whole (row-invariant) weight matrix once per row, for every storage kind.

- `TernaryF32GemvNative` gains `gemvPackedStorage()`: the same call, weight as
  a `Storage` instead of a `ByteArray`, with a default implementation (one
  transient copy + `gemvPacked`) so the two other implementations
  (`NativeKnTernaryF32Gemv` on Kotlin/Native, `JniTernaryF32Gemv` on Android)
  need no changes.
- `NativeTernaryF32GemvKernel` (JVM/FFM) overrides it: when the weight is a
  `SegmentStorage`, its `MemorySegment` is handed to the native downcall
  directly — never copied, not even once.
- `NativeTernaryF32ViewKernel.run()` dispatches on the weight's storage kind:
  `Storage.Heap` keeps today's path unchanged; `Storage.OffHeap`/`Mapped`
  routes through `gemvPackedStorage`; the per-tensor scale is read by copying
  only its trailing 4 bytes either way, never the whole weight.

## Deliberately out of scope

- `TensorView.prepack()`/Q4_K off-heap widening: unnecessary here —
  `prepack()` is never invoked for `I2_S` (only via `feedOrdered()` for
  Q4_K/Q5_K/etc.), so the real ternary chokepoint was
  `PackedBlockStorage`/`BitNetB158TensorData` directly.
- Native `GROUP_128`/`GROUP_64` decode kernels and the on-device sidecar
  cache — tracked separately as #1203/#1204/#1205 under #1198.

## Test plan

- [x] `skainet-lang-core`, `skainet-backend-api`, `skainet-io-gguf`,
      `skainet-backend-native-cpu` JVM test suites — all pass
- [x] `skainet-lang-core` binary-compatibility API dump regenerated and
      checked (additive only, no removals)
- [x] Compiled `skainet-lang-core` for `macosArm64` (Kotlin/Native) and
      `skainet-backend-native-cpu` for `macosArm64` + the Android JNI module
      (`compileDebugKotlin`) — all three `TernaryF32GemvNative` implementors
      build against the widened interface
- [x] New tests: `PlatformStorageJvmTest` copy round-trips,
      `BitNetB158TensorDataJvmTest` (off-heap decode equivalence +
      write-through), `I2sOffHeapLoadTest` (real GGUF load crossing the
      off-heap threshold), `NativeTernaryF32GemvKernelTest` (real
      `SegmentStorage` against the real bundled native library, bit-for-bit
      against `gemvPacked`), `TernaryF32KernelPackTest` (regression test that
      an off-heap weight still takes the native path, not the reference
      fallback)