### PR TITLE
Zero-copy load for SEQUENTIAL I2_S tensors — full #1203

### DIFF
--- a/skainet-io/skainet-io-core/src/jvmAndroidMain/kotlin/sk/ainet/io/JvmMappedFile.kt
+++ b/skainet-io/skainet-io-core/src/jvmAndroidMain/kotlin/sk/ainet/io/JvmMappedFile.kt
@@ -60,6 +60,19 @@ public class JvmMappedFile private constructor(
                 encoding,
             )
         }
+        // #1203: the caller (StreamingGgufParametersLoader.i2sTrailerScaleIsMappable) has already
+        // confirmed [byteOffset, byteOffset + physicalBytes) is a complete, kernel-ready
+        // BITNET_B1_58 buffer -- payload immediately followed by its own trailing FP32 scale, no
+        // repack needed at all.
+        sk.ainet.lang.tensor.storage.TensorEncoding.BITNET_B1_58 -> {
+            val length = checkNotNull(encoding.physicalBytes(shape.volume.toLong())) {
+                "${encoding.name} has size-determinate blocks"
+            }
+            sk.ainet.lang.tensor.data.BitNetB158TensorData.fromStorage(
+                shape,
+                sk.ainet.lang.memory.DirectBufferStorage.borrow(mmap.byteBufferAt(byteOffset, length)),
+            )
+        }
         else -> null
     }
 

--- a/skainet-io/skainet-io-gguf/src/commonMain/kotlin/sk/ainet/io/gguf/I2sRepack.kt
+++ b/skainet-io/skainet-io-gguf/src/commonMain/kotlin/sk/ainet/io/gguf/I2sRepack.kt
@@ -44,7 +44,11 @@ public object I2sRepack {
 
     /**
      * The sequential `BITNET_B1_58` payload of [elementCount] codes read from [bytes] under
-     * [layout]. For [I2sGgufLayout.SEQUENTIAL] the payload is validated and copied as-is.
+     * [layout]. For [I2sGgufLayout.SEQUENTIAL] the payload is validated and, when [bytes] holds
+     * exactly [elementCount]'s payload with no trailing slack to trim, returned as the same
+     * array reference — no copy (#1203): `SEQUENTIAL` is already the target byte order, so the
+     * only thing standing between it and a zero-copy load was this method defensively trimming a
+     * buffer that didn't need trimming.
      *
      * @throws IllegalArgumentException on byte code 3, or when [elementCount] does not fill
      *   [layout]'s blocks exactly
@@ -64,7 +68,7 @@ public object I2sRepack {
                     requireValidCode((b shr (lane * 2)) and 3, element)
                 }
             }
-            return bytes.copyOf(payloadBytes)
+            return if (bytes.size == payloadBytes) bytes else bytes.copyOf(payloadBytes)
         }
         val qk = layout.blockElements
         require(elementCount % qk == 0) {

--- a/skainet-io/skainet-io-gguf/src/commonMain/kotlin/sk/ainet/io/gguf/StreamingGgufParametersLoader.kt
+++ b/skainet-io/skainet-io-gguf/src/commonMain/kotlin/sk/ainet/io/gguf/StreamingGgufParametersLoader.kt
@@ -312,6 +312,16 @@ public class StreamingGgufParametersLoader(
                             GGMLQuantizationType.Q4_0 -> sk.ainet.lang.tensor.storage.TensorEncoding.Q4_0
                             GGMLQuantizationType.Q5_0 -> sk.ainet.lang.tensor.storage.TensorEncoding.Q5_0
                             GGMLQuantizationType.Q5_1 -> sk.ainet.lang.tensor.storage.TensorEncoding.Q5_1
+                            // #1203: only when the payload is already SEQUENTIAL (no permutation
+                            // needed) and the trailing bytes are genuinely the scale (no companion
+                            // tensor overrides them) -- otherwise fall through to i2sTensor's
+                            // repack, unchanged.
+                            GGMLQuantizationType.I2_S ->
+                                if (i2sTrailerScaleIsMappable(tensorInfo, tensors, source)) {
+                                    sk.ainet.lang.tensor.storage.TensorEncoding.BITNET_B1_58
+                                } else {
+                                    null
+                                }
                             else -> null
                         }
                         enc?.let { encoding ->
@@ -551,19 +561,8 @@ public class StreamingGgufParametersLoader(
         reader: StreamingGGUFReader,
         source: RandomAccessSource,
     ): Float {
-        fun trailer(): Float? = runCatching {
-            val bytes = source.readAt(tensorInfo.absoluteDataOffset + tensorInfo.nBytes, 4)
-            val bits = (bytes[0].toInt() and 0xFF) or
-                ((bytes[1].toInt() and 0xFF) shl 8) or
-                ((bytes[2].toInt() and 0xFF) shl 16) or
-                ((bytes[3].toInt() and 0xFF) shl 24)
-            Float.fromBits(bits)
-        }.getOrNull()?.takeIf { it.isFinite() && it != 0f }
-
         fun companionInverse(): Float? {
-            val companion = tensors.firstOrNull {
-                it.tensorType == GGMLQuantizationType.F32 && it.name == "${tensorInfo.name}_scale"
-            } ?: return null
+            val companion = i2sCompanionScaleTensor(tensorInfo, tensors) ?: return null
             val value = runCatching { bytesToFloatArray(reader.loadTensorData(companion)).firstOrNull() }
                 .getOrNull() ?: return null
             if (!value.isFinite() || value == 0f) return null
@@ -571,10 +570,54 @@ public class StreamingGgufParametersLoader(
         }
 
         return when (i2sLayout) {
-            I2sGgufLayout.GROUP_128, I2sGgufLayout.GROUP_64 -> trailer() ?: companionInverse() ?: 1f
-            I2sGgufLayout.SEQUENTIAL -> companionInverse() ?: trailer() ?: 1f
+            I2sGgufLayout.GROUP_128, I2sGgufLayout.GROUP_64 -> i2sTrailerScale(tensorInfo, source) ?: companionInverse() ?: 1f
+            I2sGgufLayout.SEQUENTIAL -> companionInverse() ?: i2sTrailerScale(tensorInfo, source) ?: 1f
         }
     }
+
+    /** The `<name>_scale` companion tensor for an I2_S weight, if the converter wrote one (#1140). */
+    private fun i2sCompanionScaleTensor(
+        tensorInfo: StreamingTensorInfo,
+        tensors: List<StreamingTensorInfo>,
+    ): StreamingTensorInfo? = tensors.firstOrNull {
+        it.tensorType == GGMLQuantizationType.F32 && it.name == "${tensorInfo.name}_scale"
+    }
+
+    /**
+     * The little-endian FP32 immediately after [tensorInfo]'s payload — BitNet.cpp's trailer
+     * convention — or `null` if unreadable, non-finite, or zero. [StreamingTensorInfo.nBytes]
+     * deliberately sizes the payload only, so `absoluteDataOffset + nBytes` is exactly where a
+     * trailer would start.
+     */
+    private fun i2sTrailerScale(tensorInfo: StreamingTensorInfo, source: RandomAccessSource): Float? = runCatching {
+        val bytes = source.readAt(tensorInfo.absoluteDataOffset + tensorInfo.nBytes, 4)
+        val bits = (bytes[0].toInt() and 0xFF) or
+            ((bytes[1].toInt() and 0xFF) shl 8) or
+            ((bytes[2].toInt() and 0xFF) shl 16) or
+            ((bytes[3].toInt() and 0xFF) shl 24)
+        Float.fromBits(bits)
+    }.getOrNull()?.takeIf { it.isFinite() && it != 0f }
+
+    /**
+     * Whether an I2_S tensor's on-disk bytes are, as-is, a complete kernel-ready `BITNET_B1_58`
+     * buffer — payload immediately followed by its own trailing FP32 scale — so mapping
+     * `[absoluteDataOffset, absoluteDataOffset + nBytes + 4)` directly gives exactly what
+     * [resolveI2sScale] would have computed anyway (#1203).
+     *
+     * Only ever true for [I2sGgufLayout.SEQUENTIAL]: the payload itself is already in
+     * `BITNET_B1_58` order there, whereas `GROUP_128`/`GROUP_64` payloads still need permuting
+     * regardless of where the scale lives. False whenever a companion `<name>_scale` tensor
+     * exists — [resolveI2sScale]'s `SEQUENTIAL` order prefers it over a trailer — or the trailer
+     * bytes don't parse to a finite, nonzero float.
+     */
+    private fun i2sTrailerScaleIsMappable(
+        tensorInfo: StreamingTensorInfo,
+        tensors: List<StreamingTensorInfo>,
+        source: RandomAccessSource,
+    ): Boolean =
+        i2sLayout == I2sGgufLayout.SEQUENTIAL &&
+            i2sCompanionScaleTensor(tensorInfo, tensors) == null &&
+            i2sTrailerScale(tensorInfo, source) != null
 
     /**
      * Materialize an I2_S tensor (#1140): repack the payload into the sequential `BITNET_B1_58`

--- a/skainet-io/skainet-io-gguf/src/jvmTest/kotlin/sk/ainet/io/gguf/I2sMappedFastPathTest.kt
+++ b/skainet-io/skainet-io-gguf/src/jvmTest/kotlin/sk/ainet/io/gguf/I2sMappedFastPathTest.kt
@@ -1,0 +1,133 @@
+package sk.ainet.io.gguf
+
+import kotlinx.coroutines.runBlocking
+import sk.ainet.context.DefaultDataExecutionContext
+import sk.ainet.io.JvmRandomAccessSource
+import sk.ainet.lang.memory.ExperimentalMemoryApi
+import sk.ainet.lang.memory.Storage
+import sk.ainet.lang.memory.plan.WeightForm
+import sk.ainet.lang.memory.plan.WeightResidency
+import sk.ainet.lang.tensor.Tensor
+import sk.ainet.lang.tensor.data.BitNetB158TensorData
+import sk.ainet.lang.types.FP32
+import java.io.File
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertIs
+
+/**
+ * #1203, second half: a `SEQUENTIAL`-layout I2_S tensor whose on-disk bytes are already a
+ * complete `BITNET_B1_58` buffer (payload + its own trailing FP32 scale, no companion tensor to
+ * override it) must load through [sk.ainet.io.JvmMappedFile]'s mmap branch — zero heap bytes,
+ * zero repack — while every other case keeps today's heap-staged repack path.
+ */
+@OptIn(ExperimentalMemoryApi::class)
+class I2sMappedFastPathTest {
+
+    private fun sequentialPayload(codes: IntArray): ByteArray {
+        val out = ByteArray(codes.size / 4)
+        for (j in codes.indices) {
+            out[j / 4] = (out[j / 4].toInt() or (codes[j] shl ((j % 4) * 2))).toByte()
+        }
+        return out
+    }
+
+    private fun groupPayload(codes: IntArray, qk: Int): ByteArray {
+        val bytesPerBlock = qk / 4
+        val out = ByteArray(codes.size / 4)
+        for (j in codes.indices) {
+            val jb = j % qk
+            val byteIndex = (j / qk) * bytesPerBlock + jb % bytesPerBlock
+            out[byteIndex] = (out[byteIndex].toInt() or (codes[j] shl (6 - 2 * (jb / bytesPerBlock)))).toByte()
+        }
+        return out
+    }
+
+    private fun leFloat(value: Float): ByteArray =
+        ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putFloat(value).array()
+
+    private fun randomCodes(count: Int, seed: Int): IntArray {
+        val rng = Random(seed)
+        return IntArray(count) { rng.nextInt(3) } // {0, 1, 2} — never 3
+    }
+
+    private fun load(
+        f: File,
+        layout: I2sGgufLayout,
+        form: WeightForm,
+    ): Tensor<FP32, Float> {
+        val ctx = DefaultDataExecutionContext()
+        var tensor: Tensor<FP32, Float>? = null
+        runBlocking {
+            StreamingGgufParametersLoader(
+                sourceProvider = { JvmRandomAccessSource.open(f) },
+                weightForm = form,
+                i2sLayout = layout,
+            ).load<FP32, Float>(ctx, FP32::class) { _, t -> tensor = t }
+        }
+        return tensor!!
+    }
+
+    @Test
+    fun sequentialWithATrailerAndNoCompanionMapsDirectlyOffTheFile() {
+        val elements = 256
+        val codes = randomCodes(elements, seed = 1)
+        val bytes = sequentialPayload(codes) + leFloat(0.25f)
+        val f = SyntheticGguf.write(SyntheticGguf.TestTensor("w", GGMLQuantizationType.I2_S, elements.toLong(), bytes))
+        try {
+            val mapped = load(f, I2sGgufLayout.SEQUENTIAL, WeightForm(residency = WeightResidency.MAPPED))
+            val packed = assertIs<BitNetB158TensorData>(mapped.data)
+            assertIs<Storage.OffHeap>(packed.packedStorage, "must be served over the file mapping, not a heap copy")
+
+            val heap = load(f, I2sGgufLayout.SEQUENTIAL, WeightForm(residency = WeightResidency.HEAP))
+            assertContentEquals(
+                (heap.data as BitNetB158TensorData).toFloatArray(),
+                packed.toFloatArray(),
+                "mapped values must equal the heap-staged load",
+            )
+        } finally {
+            f.delete()
+        }
+    }
+
+    @Test
+    fun sequentialWithACompanionScaleStillRepacksOnHeap() {
+        // The companion wins over a trailer for SEQUENTIAL (resolveI2sScale's own order), so even
+        // though a trailer-shaped tail exists here too, the mmap fast path must not fire — its
+        // bytes wouldn't be the real scale.
+        val elements = 256
+        val codes = randomCodes(elements, seed = 2)
+        val payload = sequentialPayload(codes)
+        val f = SyntheticGguf.write(
+            SyntheticGguf.TestTensor("w", GGMLQuantizationType.I2_S, elements.toLong(), payload),
+            SyntheticGguf.TestTensor("w_scale", GGMLQuantizationType.F32, 1L, leFloat(4f)), // divide-by convention
+        )
+        try {
+            val mapped = load(f, I2sGgufLayout.SEQUENTIAL, WeightForm(residency = WeightResidency.MAPPED))
+            val packed = assertIs<BitNetB158TensorData>(mapped.data)
+            assertIs<Storage.Heap>(packed.packedStorage, "a companion-scale tensor must still repack, not mmap")
+        } finally {
+            f.delete()
+        }
+    }
+
+    @Test
+    fun group128NeverTakesTheMmapFastPathRegardlessOfTheTrailer() {
+        // GROUP_128 payload bytes are not BITNET_B1_58-ordered — the mmap fast path must never
+        // fire for it, trailer or not, since the raw bytes would be wrong without a repack.
+        val elements = 256
+        val codes = randomCodes(elements, seed = 3)
+        val bytes = groupPayload(codes, qk = 128) + leFloat(0.5f)
+        val f = SyntheticGguf.write(SyntheticGguf.TestTensor("w", GGMLQuantizationType.I2_S, elements.toLong(), bytes))
+        try {
+            val mapped = load(f, I2sGgufLayout.GROUP_128, WeightForm(residency = WeightResidency.MAPPED))
+            val packed = assertIs<BitNetB158TensorData>(mapped.data)
+            assertIs<Storage.Heap>(packed.packedStorage, "GROUP_128 must always repack, never mmap directly")
+        } finally {
+            f.delete()
+        }
+    }
+}

--- a/skainet-io/skainet-io-gguf/src/jvmTest/kotlin/sk/ainet/io/gguf/I2sRepackTest.kt
+++ b/skainet-io/skainet-io-gguf/src/jvmTest/kotlin/sk/ainet/io/gguf/I2sRepackTest.kt
@@ -61,6 +61,17 @@ class I2sRepackTest {
     }
 
     @Test
+    fun sequentialWithNoTrailingSlackReturnsTheSameArrayNoCopy() {
+        // #1203: when the input is already exactly the payload (no trailer to trim), the method
+        // must hand back the same array reference — not just content-equal bytes — so a caller can
+        // treat it as a genuine zero-copy pass-through rather than a hidden defensive copy.
+        val codes = randomCodes(64, seed = 4)
+        val bytes = packSequential(codes)
+        val out = I2sRepack.toSequentialPayload(bytes, 64, I2sGgufLayout.SEQUENTIAL)
+        assertTrue(bytes === out, "expected the identical array back, got a copy")
+    }
+
+    @Test
     fun byteCode3FailsFastInEveryLayout() {
         for (layout in I2sGgufLayout.entries) {
             val bytes = ByteArray(128 / 4) // 128 elements of code 0...


### PR DESCRIPTION
Sub-issue of #1198. Both halves of #1203 (updated from the original part-1-only scope).

## Problem

For `SEQUENTIAL`-layout (NeoGPU-converted) I2_S tensors, the loader always repacked and
heap-staged the payload, even though `SEQUENTIAL` is already the kernel-ready byte order —
no permutation needed, unlike `GROUP_128`/`GROUP_64`.

## Part 1 — skip the redundant copy

`I2sRepack.toSequentialPayload` always copied its input for `SEQUENTIAL`, even when the input
already was exactly the target payload with no trailing slack to trim. Now returns the same
array reference in that case.

## Part 2 — true zero-copy mmap

Digging into the actual mmap machinery revealed the mmap decision isn't made in
`i2sTensor()`/`quantizedTensor()` at all — it's a separate, earlier branch in `load()` keyed on a
hardcoded encoding whitelist that didn't include `I2_S`, mapping one contiguous byte range per
tensor on the assumption the encoding is self-describing within it. `BITNET_B1_58` isn't always:
its scale is either a trailer right after the payload (mappable as one range) or, for the common
NeoGPU companion-scale case, a *separate* tensor elsewhere in the file (not contiguous with the
payload).

- `StreamingGgufParametersLoader.i2sTrailerScaleIsMappable()`: true only when
  `layout == SEQUENTIAL`, no companion `<name>_scale` tensor exists (`SEQUENTIAL`'s resolution
  order prefers a companion over a trailer), and the trailing 4 bytes parse to a finite, nonzero
  float — i.e. exactly when `resolveI2sScale` would already resolve to that trailer, so the
  mapped bytes can never disagree with what the non-mapped path would compute.
- The mmap branch's encoding whitelist gains `I2_S`, gated on that check, producing
  `TensorEncoding.BITNET_B1_58`.
- `JvmMappedFile.packedTensor()` gains a `BITNET_B1_58` case: maps
  `[byteOffset, byteOffset + physicalBytes)` as a `BitNetB158TensorData.fromStorage()` view —
  same `DirectBufferStorage.borrow(mmap.byteBufferAt(...))` pattern the existing Q4_K/Q6_K/etc.
  cases already use.

`GROUP_128`/`GROUP_64` and `SEQUENTIAL`-with-a-companion-scale are unaffected — they still
repack through `i2sTensor()` exactly as before (now benefiting from #1202's off-heap storage and
this PR's no-copy-on-already-sequential fix).

## Test plan

- [x] `skainet-io-gguf`, `skainet-io-core` JVM test suites pass
- [x] `skainet-lang-core` `apiCheck` passes (no public API change)
- [x] `sequentialWithNoTrailingSlackReturnsTheSameArrayNoCopy` — reference-identity (`===`), not
      just content equality
- [x] New `I2sMappedFastPathTest`: a trailer-scaled, no-companion `SEQUENTIAL` tensor maps
      directly off the file (`packedStorage is Storage.OffHeap`, values equal the heap load); a
      companion-scale `SEQUENTIAL` tensor and a `GROUP_128` tensor (even with a trailer-shaped
      tail) both still repack on heap — proving the fast path never fires when it would disagree
      with `resolveI2sScale`