### PR TITLE
fix(build): ELF-aware ar/ranlib for the aarch64 cross build on macOS hosts

### DIFF
--- a/skainet-backends/skainet-backend-native-cpu/build.gradle.kts
+++ b/skainet-backends/skainet-backend-native-cpu/build.gradle.kts
@@ -316,6 +316,12 @@ val configureNativeKernelsArm64 by tasks.registering(Exec::class) {
         "-DCMAKE_BUILD_TYPE=Release",
         "-DCMAKE_TOOLCHAIN_FILE=$toolchainFilePath",
         "-DSKAINET_AARCH64_CC=$aarch64Cc",
+    ) + listOfNotNull(
+        // Cross-archiving from a macOS host needs an ELF-aware ar/ranlib (the
+        // BSD defaults silently emit an EMPTY archive from ELF objects) — see
+        // toolchain-aarch64.cmake. Optional overrides, e.g. Konan's llvm-ar.
+        (findProperty("skainetAarch64Ar") as String?)?.let { "-DSKAINET_AARCH64_AR=$it" },
+        (findProperty("skainetAarch64Ranlib") as String?)?.let { "-DSKAINET_AARCH64_RANLIB=$it" },
     )
 }
 

--- a/skainet-backends/skainet-backend-native-cpu/native/toolchain-aarch64.cmake
+++ b/skainet-backends/skainet-backend-native-cpu/native/toolchain-aarch64.cmake
@@ -21,6 +21,21 @@ if(NOT DEFINED SKAINET_AARCH64_CC)
 endif()
 set(CMAKE_C_COMPILER ${SKAINET_AARCH64_CC})
 
+# The archiver must understand ELF objects. On a macOS host the default
+# /usr/bin/ar + ranlib silently produce an EMPTY archive from cross-compiled
+# ELF objects (just a __.SYMDEF), which then surfaces downstream as
+# "undefined symbol: skainet_*" when a consumer links the published klib.
+# Allow -DSKAINET_AARCH64_AR/-DSKAINET_AARCH64_RANLIB overrides, and default
+# to llvm-ar/llvm-ranlib when they are on the PATH (they handle ELF anywhere).
+if(NOT DEFINED SKAINET_AARCH64_AR)
+    find_program(SKAINET_AARCH64_AR NAMES llvm-ar aarch64-linux-gnu-gcc-ar ar)
+endif()
+if(NOT DEFINED SKAINET_AARCH64_RANLIB)
+    find_program(SKAINET_AARCH64_RANLIB NAMES llvm-ranlib aarch64-linux-gnu-gcc-ranlib ranlib)
+endif()
+set(CMAKE_AR ${SKAINET_AARCH64_AR})
+set(CMAKE_RANLIB ${SKAINET_AARCH64_RANLIB})
+
 # Search for libraries/headers only in the target sysroot, but find
 # programs (the compiler) on the host.
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)


### PR DESCRIPTION
Found while validating the transformers 0.51 migration against a locally published snapshot: on a macOS host the aarch64 cross build's static archive was silently **empty** (BSD ar/ranlib emit just a `__.SYMDEF` from ELF objects), so published linuxArm64 klibs shipped without the C kernels and consumers failed at link with `undefined symbol: skainet_q4k_matmul` et al.

- `toolchain-aarch64.cmake` resolves `CMAKE_AR`/`CMAKE_RANLIB` (overridable via `-DSKAINET_AARCH64_AR/-DSKAINET_AARCH64_RANLIB`, preferring `llvm-ar`).
- The gradle configure task forwards matching `-PskainetAarch64Ar/Ranlib` properties — e.g. Konan's bundled `llvm-ar` plus a one-line ranlib wrapper on a Mac.

Verified: archive goes 96 B → 57 KB with all symbols (`_rm` twins included); a linuxArm64 consumer executable links clean against the republished snapshot. Linux CI hosts are unaffected (their default ar handles ELF; `find_program` picks the same tools as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)