### PR TITLE
docs(compliance): the klib notice stance (#1166)

### DIFF
--- a/skainet-backends/skainet-backend-jni-cpu/src/main/resources/META-INF/THIRD-PARTY-NOTICES.md
+++ b/skainet-backends/skainet-backend-jni-cpu/src/main/resources/META-INF/THIRD-PARTY-NOTICES.md
@@ -51,3 +51,21 @@ The I2_S GGUF wire-format handling in `skainet-io-gguf` was written against the
 sources of [BitNet.cpp](https://github.com/microsoft/BitNet) (MIT, © Microsoft
 Corporation) — a reimplementation of the layout rules, not copied code. See the
 interpretation notes in `sk.ainet.io.gguf.I2sRepack`.
+
+## Kotlin/Native klibs — how this notice reaches them
+
+Kotlin/Native klibs have no `META-INF` resource mechanism, so this file cannot
+physically travel inside the klib the way it travels inside the JVM jar and the
+Android AAR. The stance for klib consumers, decided in
+[#1166](https://github.com/SKaiNET-developers/SKaiNET/issues/1166):
+
+- The klibs of a release embed the same static archive compiled from the same
+  sources as the jar in **the same Maven artifact family and version** — this
+  notice, shipped in that release's jar, is the authoritative notice for every
+  artifact of the release, klibs included.
+- The source of truth is versioned in the repository: `LICENSES/MIT.txt`, the
+  `.license` sidecar next to the vendored file, and
+  `native/src/vendor/neogpu/README.md`.
+- An application that links a SKaiNET klib into a shipped binary should carry
+  the NeoGPU MIT notice in its own third-party attributions (as it should for
+  any statically linked MIT code); the license text above is the text to carry.

--- a/skainet-backends/skainet-backend-native-cpu/src/jvmMain/resources/META-INF/THIRD-PARTY-NOTICES.md
+++ b/skainet-backends/skainet-backend-native-cpu/src/jvmMain/resources/META-INF/THIRD-PARTY-NOTICES.md
@@ -52,3 +52,21 @@ The I2_S GGUF wire-format handling in `skainet-io-gguf` was written against the
 sources of [BitNet.cpp](https://github.com/microsoft/BitNet) (MIT, © Microsoft
 Corporation) — a reimplementation of the layout rules, not copied code. See the
 interpretation notes in `sk.ainet.io.gguf.I2sRepack`.
+
+## Kotlin/Native klibs — how this notice reaches them
+
+Kotlin/Native klibs have no `META-INF` resource mechanism, so this file cannot
+physically travel inside the klib the way it travels inside the JVM jar and the
+Android AAR. The stance for klib consumers, decided in
+[#1166](https://github.com/SKaiNET-developers/SKaiNET/issues/1166):
+
+- The klibs of a release embed the same static archive compiled from the same
+  sources as the jar in **the same Maven artifact family and version** — this
+  notice, shipped in that release's jar, is the authoritative notice for every
+  artifact of the release, klibs included.
+- The source of truth is versioned in the repository: `LICENSES/MIT.txt`, the
+  `.license` sidecar next to the vendored file, and
+  `native/src/vendor/neogpu/README.md`.
+- An application that links a SKaiNET klib into a shipped binary should carry
+  the NeoGPU MIT notice in its own third-party attributions (as it should for
+  any statically linked MIT code); the license text above is the text to carry.


### PR DESCRIPTION
The klib-coverage decision #1166's checklist flagged: Kotlin/Native klibs have no `META-INF` resource mechanism, so `THIRD-PARTY-NOTICES.md` cannot physically travel inside them the way it does in the jar and AAR — yet the klibs embed the same compiled NeoGPU code.

The stance, now documented in both notices files where an auditor will look:

1. The jar of the same Maven artifact family and version carries the authoritative notice for **every** artifact of the release, klibs included.
2. The versioned source of truth is in-repo: `LICENSES/MIT.txt`, the `.license` sidecar, the vendor README.
3. An application statically linking a SKaiNET klib carries the NeoGPU MIT notice in its own third-party attributions — as for any statically linked MIT code; the notices file gives the exact text to carry.

With this, every technical checklist item of #1166 is done; what remains there is the upstream courtesies (drafted, awaiting the maintainer's go) and the close-out summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKeDSK4JF295y53Uvez954