### PR TITLE
security: pin fast-uri 3.1.6, qs 6.16.0 (6 npm advisories)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,7 @@ skainet {
         pin("socket.io-parser", libs.versions.npm.socketio.parser, NpmPinTarget.JS)
         pin("fast-uri", libs.versions.npm.fast.uri, NpmPinTarget.JS)
         pin("serialize-javascript", libs.versions.npm.serialize.javascript, NpmPinTarget.JS)
+        pin("qs", libs.versions.npm.qs, NpmPinTarget.JS)
         pin("brace-expansion", libs.versions.npm.brace.expansion, NpmPinTarget.JS)
         pin("diff", libs.versions.npm.diff, NpmPinTarget.JS)
         pin("webpack", libs.versions.npm.webpack, NpmPinTarget.JS)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,8 +50,10 @@ kotest = "6.2.4"
 npm-ws = "8.21.1"   # GHSA-96hv-2xvq-fx4p
 npm-js-yaml = "4.3.1"              # GHSA-5p4m-2wfm-xmqj
 npm-socketio-parser = "4.2.7"      # GHSA-2m8v-j782-fhvr
-npm-fast-uri = "3.1.5"             # GHSA-7p8r-x3mc-p8w7, GHSA-v2hh-gcrm-f6hx
+npm-fast-uri = "3.1.6"             # GHSA-7p8r-x3mc-p8w7, GHSA-v2hh-gcrm-f6hx, GHSA-jqff-g426-hqxp,
+                                    # GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf, GHSA-5jgf-p345-68v8
 npm-serialize-javascript = "7.0.5" # GHSA-5c6j-r48x-rmvq, GHSA-qj8w-gfj5-8c6v
+npm-qs = "6.16.0"                  # GHSA-4mjr-xmp4-gh2g, GHSA-x5fp-wj9c-mxmx
 # One pin covers both major lines in the graph: minimatch 3.x asks for ^1.1.7 and
 # minimatch 9.x for ^2.0.2, and a Yarn resolution is global. 2.1.4 clears the fixed
 # set of both advisories (<1.1.18 and >=2.0.0 <2.1.4); the exported API is unchanged

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -792,10 +792,10 @@ fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-uri@3.1.5, fast-uri@^3.0.1:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
-  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
+fast-uri@3.1.6, fast-uri@^3.0.1:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.6.tgz#bfdd308ef763f835fed059f3c6c925f708e33e3a"
+  integrity sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==
 
 fastest-levenshtein@^1.0.12:
   version "1.0.16"
@@ -1547,10 +1547,10 @@ qjobs@^1.2.0:
   resolved "https://registry.yarnpkg.com/qjobs/-/qjobs-1.2.0.tgz#c45e9c61800bd087ef88d7e256423bdd49e5d071"
   integrity sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==
 
-qs@~6.15.1:
-  version "6.15.3"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.3.tgz#76852132a58ed5c7c0ef67e4441b9bb5d6061b3b"
-  integrity sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==
+qs@6.16.0, qs@~6.15.1:
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.16.0.tgz#c22c723a28a920f3aacdce8289fabd43eccb79fd"
+  integrity sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==
   dependencies:
     es-define-property "^1.0.1"
     side-channel "^1.1.1"


### PR DESCRIPTION
## Summary
Fixes the 4 high + 2 medium Dependabot alerts in `kotlin-js-store/yarn.lock` using the existing `sk.ainet.npm-pins` mechanism:
- `fast-uri`: 3.1.5 → 3.1.6 (the existing pin was below the fix floor for 4 newer advisories — host confusion / SSRF via scheme, IPv6, and IDN normalization bugs)
- `qs`: unpinned → 6.16.0 (new pin; was resolving to ~6.15.1, vulnerable to a DoS and an array-limit bypass)

Both packages exist only in the JS Yarn graph, not the Wasm one, so both are `NpmPinTarget.JS`-scoped.

## Not covered by this PR
The remaining 11 open alerts (Jackson, jsoup, BouncyCastle, httpclient, OpenTelemetry, Commons Lang3, kotlin-gradle-plugin) all trace back into the internal, isolated dependency graphs of third-party Gradle plugins — Android Gradle Plugin 9.4.0 and Dokka 2.2.0 (both already the latest stable releases), plus what looks like the Kotlin Build Tools API's own resolution. None of these are reachable by `sk.ainet.maven-pins` (which only patches `project.allprojects` configurations, not plugin/buildscript classpaths), and there's no newer AGP/Dokka release yet to bump to. `kotlin-gradle-plugin`'s own CVE (unsafe build-cache deserialization) is fixed only in a `2.4.20-Beta1` prerelease — not something to adopt for a stable toolchain yet. Recommend revisiting once AGP/Dokka/Kotlin ship patched stable releases.

## Test plan
- [x] `kotlinUpgradeYarnLock` + `kotlinWasmUpgradeYarnLock` regenerated the lockfiles
- [x] `./gradlew verifyNpmPins` — 9 pins verified
- [x] JS + wasmJs compile clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLfVvtURRYZETceamLi8kP